### PR TITLE
feat: replace JSON output with TOON format

### DIFF
--- a/src/Drivers/Paratest/WrapperRunner.php
+++ b/src/Drivers/Paratest/WrapperRunner.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Pao\Drivers\Paratest;
 
-use JsonException;
 use Pao\Execution;
+use Pao\Support\ToonEncoder;
 use ParaTest\Options;
 use ParaTest\RunnerInterface;
 use ParaTest\WrapperRunner\WrapperRunner as ParatestWrapperRunner;
@@ -28,9 +28,6 @@ final readonly class WrapperRunner implements RunnerInterface
         $this->runner = new ParatestWrapperRunner($options, new NullOutput);
     }
 
-    /**
-     * @throws JsonException
-     */
     public function run(): int
     {
         $exitCode = $this->runner->run();
@@ -41,7 +38,7 @@ final readonly class WrapperRunner implements RunnerInterface
         $result = $execution->result();
 
         if ($result !== null) {
-            $this->output->writeln(json_encode($result, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+            $this->output->writeln(ToonEncoder::encode($result));
         }
 
         return $exitCode;

--- a/src/Drivers/Pest/Plugin.php
+++ b/src/Drivers/Pest/Plugin.php
@@ -6,6 +6,7 @@ namespace Pao\Drivers\Pest;
 
 use Pao\Drivers\Phpunit\Extension;
 use Pao\Execution;
+use Pao\Support\ToonEncoder;
 use Pao\UserFilters\CaptureFilter;
 use Pest\Contracts\Plugins\AddsOutput;
 use Pest\Contracts\Plugins\HandlesArguments;
@@ -92,7 +93,7 @@ final class Plugin implements AddsOutput, HandlesArguments, Terminable
             }
         }
 
-        $this->output->writeln(json_encode($this->result, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        $this->output->writeln(ToonEncoder::encode($this->result));
 
         $this->result = null;
     }

--- a/src/Drivers/Phpunit/Subscribers/TestRunnerFinishedSubscriber.php
+++ b/src/Drivers/Phpunit/Subscribers/TestRunnerFinishedSubscriber.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Pao\Drivers\Phpunit\Subscribers;
 
-use JsonException;
 use Pao\Execution;
+use Pao\Support\ToonEncoder;
 use PHPUnit\Event\TestRunner\Finished;
 use PHPUnit\Event\TestRunner\FinishedSubscriber;
 
@@ -16,9 +16,6 @@ use PHPUnit\Event\TestRunner\FinishedSubscriber;
  */
 final readonly class TestRunnerFinishedSubscriber implements FinishedSubscriber
 {
-    /**
-     * @throws JsonException
-     */
     public function notify(Finished $event): void
     {
         $execution = Execution::current();
@@ -33,6 +30,6 @@ final readonly class TestRunnerFinishedSubscriber implements FinishedSubscriber
             return;
         }
 
-        fwrite(STDOUT, json_encode($data, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL);
+        fwrite(STDOUT, ToonEncoder::encode($data).PHP_EOL);
     }
 }

--- a/src/Support/ToonDecoder.php
+++ b/src/Support/ToonDecoder.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pao\Support;
+
+/**
+ * Decodes TOON (Token-Oriented Object Notation) output back into an array.
+ *
+ * @link https://github.com/toon-format/spec
+ *
+ * @internal
+ *
+ * @phpstan-import-type Result from \Pao\Execution
+ */
+final class ToonDecoder
+{
+    /**
+     * @return Result
+     */
+    public static function decode(string $toon): array
+    {
+        $lines = explode("\n", $toon);
+        /** @var Result $result */
+        $result = [];
+        $i = 0;
+        $count = count($lines);
+
+        while ($i < $count) {
+            $line = $lines[$i];
+
+            if ($line === '' || ctype_space($line)) {
+                $i++;
+
+                continue;
+            }
+
+            if (preg_match('/^(\w+)\[(\d+)]\{(.+)}:\s*$/', $line, $matches) === 1) {
+                $key = $matches[1];
+                $expectedCount = (int) $matches[2];
+                $fields = explode(',', $matches[3]);
+                $rows = [];
+                $i++;
+
+                for ($r = 0; $r < $expectedCount && $i < $count; $r++, $i++) {
+                    $rowLine = ltrim($lines[$i]);
+
+                    if ($rowLine === '') {
+                        $r--;
+
+                        continue;
+                    }
+
+                    $values = self::parseCsvRow($rowLine, count($fields));
+                    /** @var array<string, string|int> $row */
+                    $row = [];
+
+                    foreach ($fields as $fi => $field) {
+                        $value = $values[$fi] ?? '';
+                        $row[$field] = is_numeric($value) && ! str_contains($value, ' ') ? (int) $value : $value;
+                    }
+
+                    $rows[] = $row;
+                }
+
+                $result[$key] = $rows;
+
+                continue;
+            }
+
+            if (preg_match('/^(\w+)\[(\d+)]:\s*$/', $line, $matches) === 1) {
+                $key = $matches[1];
+                $expectedCount = (int) $matches[2];
+                $items = [];
+                $i++;
+
+                for ($r = 0; $r < $expectedCount && $i < $count; $r++, $i++) {
+                    $itemLine = $lines[$i];
+                    $itemLine = preg_replace('/^\s*-\s*/', '', $itemLine) ?? $itemLine;
+                    $items[] = self::unescapeValue(trim($itemLine));
+                }
+
+                $result[$key] = $items;
+
+                continue;
+            }
+
+            if (preg_match('/^(\w+):\s*(.*)$/', $line, $matches) === 1) {
+                $key = $matches[1];
+                $value = $matches[2];
+
+                $result[$key] = match (true) {
+                    $value === 'true' => true,
+                    $value === 'false' => false,
+                    $value === 'null' => null,
+                    is_numeric($value) && ! str_contains($value, ' ') => str_contains($value, '.') ? (float) $value : (int) $value,
+                    default => self::unescapeValue($value),
+                };
+            }
+
+            $i++;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function parseCsvRow(string $row, int $fieldCount): array
+    {
+        $values = [];
+        $current = '';
+        $inQuotes = false;
+        $len = strlen($row);
+
+        for ($i = 0; $i < $len; $i++) {
+            $char = $row[$i];
+
+            if ($inQuotes) {
+                if ($char === '\\' && $i + 1 < $len) {
+                    $next = $row[$i + 1];
+                    $current .= match ($next) {
+                        'n' => "\n",
+                        'r' => "\r",
+                        't' => "\t",
+                        '"' => '"',
+                        '\\' => '\\',
+                        default => '\\'.$next,
+                    };
+                    $i++;
+                } elseif ($char === '"') {
+                    $inQuotes = false;
+                } else {
+                    $current .= $char;
+                }
+            } elseif ($char === '"') {
+                $inQuotes = true;
+            } elseif ($char === ',' && count($values) < $fieldCount - 1) {
+                $values[] = $current;
+                $current = '';
+            } else {
+                $current .= $char;
+            }
+        }
+
+        $values[] = $current;
+
+        return $values;
+    }
+
+    private static function unescapeValue(string $value): string
+    {
+        if (strlen($value) >= 2 && $value[0] === '"' && $value[strlen($value) - 1] === '"') {
+            $value = substr($value, 1, -1);
+            $value = str_replace('\\n', "\n", $value);
+            $value = str_replace('\\r', "\r", $value);
+            $value = str_replace('\\t', "\t", $value);
+            $value = str_replace('\\"', '"', $value);
+            $value = str_replace('\\\\', '\\', $value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Support/ToonDecoder.php
+++ b/src/Support/ToonDecoder.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Pao\Support;
 
 /**
- * Decodes TOON (Token-Oriented Object Notation) output back into an array.
- *
  * @link https://github.com/toon-format/spec
  *
  * @internal

--- a/src/Support/ToonEncoder.php
+++ b/src/Support/ToonEncoder.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Pao\Support;
 
 /**
- * Encodes the test result into TOON (Token-Oriented Object Notation) format.
- *
  * @link https://github.com/toon-format/spec
  *
  * @internal

--- a/src/Support/ToonEncoder.php
+++ b/src/Support/ToonEncoder.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pao\Support;
+
+/**
+ * Encodes the test result into TOON (Token-Oriented Object Notation) format.
+ *
+ * @link https://github.com/toon-format/spec
+ *
+ * @internal
+ *
+ * @phpstan-import-type Result from \Pao\Execution
+ */
+final class ToonEncoder
+{
+    /**
+     * @param  Result  $data
+     */
+    public static function encode(array $data): string
+    {
+        $lines = [];
+
+        $lines[] = 'result: '.$data['result'];
+        $lines[] = 'tests: '.$data['tests'];
+        $lines[] = 'passed: '.$data['passed'];
+        $lines[] = 'duration_ms: '.$data['duration_ms'];
+
+        if (isset($data['failed'])) {
+            $lines[] = 'failed: '.$data['failed'];
+        }
+
+        if (isset($data['failures']) && $data['failures'] !== []) {
+            self::encodeTestDetails($lines, 'failures', $data['failures']);
+        }
+
+        if (isset($data['errors'])) {
+            $lines[] = 'errors: '.$data['errors'];
+        }
+
+        if (isset($data['error_details']) && $data['error_details'] !== []) {
+            self::encodeTestDetails($lines, 'error_details', $data['error_details']);
+        }
+
+        if (isset($data['skipped'])) {
+            $lines[] = 'skipped: '.$data['skipped'];
+        }
+
+        if (isset($data['output']) && $data['output'] !== []) {
+            $count = count($data['output']);
+            $lines[] = "output[{$count}]:";
+
+            foreach ($data['output'] as $line) {
+                $lines[] = ' - '.self::escapeValue($line);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param  list<string>  $lines
+     * @param  list<array{test: string, file: string, line: int, message: string}>  $details
+     */
+    private static function encodeTestDetails(array &$lines, string $key, array $details): void
+    {
+        $count = count($details);
+        $lines[] = "{$key}[{$count}]{test,file,line,message}:";
+
+        foreach ($details as $detail) {
+            $lines[] = ' '.implode(',', [
+                self::escapeValue($detail['test']),
+                self::escapeValue($detail['file']),
+                $detail['line'],
+                self::escapeValue($detail['message']),
+            ]);
+        }
+    }
+
+    private static function escapeValue(string $value): string
+    {
+        if ($value === '') {
+            return '""';
+        }
+
+        $needsQuoting = str_contains($value, ',')
+            || str_contains($value, "\n")
+            || str_contains($value, "\r")
+            || str_contains($value, '"')
+            || $value !== trim($value);
+
+        if (! $needsQuoting) {
+            return $value;
+        }
+
+        $escaped = str_replace('\\', '\\\\', $value);
+        $escaped = str_replace('"', '\\"', $escaped);
+        $escaped = str_replace("\n", '\\n', $escaped);
+        $escaped = str_replace("\r", '\\r', $escaped);
+
+        return '"'.$escaped.'"';
+    }
+}

--- a/tests/Drivers/EdgeCasesTest.php
+++ b/tests/Drivers/EdgeCasesTest.php
@@ -10,11 +10,7 @@ it('does not break tests that read argv', function (): void {
 });
 
 it('does not break tests that fwrite to stdout', function (): void {
-    $process = runWith('phpunit', 'StdoutWriteTest');
-    $raw = $process->getOutput();
-
-    $jsonStart = strpos($raw, '{');
-    $output = json_decode(substr($raw, (int) $jsonStart), associative: true, flags: JSON_THROW_ON_ERROR);
+    $output = decodeFromMixedOutput(runWith('phpunit', 'StdoutWriteTest'));
 
     expect($output['result'])->toBe('passed')
         ->and($output['tests'])->toBe(2);
@@ -48,7 +44,7 @@ it('works correctly when no agent is detected and does not affect output', funct
     $output = $process->getOutput();
 
     expect($output)->toContain('OK')
-        ->and($output)->not->toContain('"result"')
+        ->and($output)->not->toContain('result: passed')
         ->and($output)->not->toContain('agent-output');
 });
 
@@ -95,11 +91,7 @@ it('does not break tests with BackupGlobals', function (): void {
 });
 
 it('does not break with large test output', function (): void {
-    $process = runWith('phpunit', 'LargeOutputTest');
-    $raw = $process->getOutput();
-
-    $jsonStart = strpos($raw, '{');
-    $output = json_decode(substr($raw, (int) $jsonStart), associative: true, flags: JSON_THROW_ON_ERROR);
+    $output = decodeFromMixedOutput(runWith('phpunit', 'LargeOutputTest'));
 
     expect($output['result'])->toBe('passed')
         ->and($output['tests'])->toBe(1);

--- a/tests/Drivers/ParatestTest.php
+++ b/tests/Drivers/ParatestTest.php
@@ -112,6 +112,6 @@ it('outputs json for multiple failures and errors', function (): void {
 it('outputs normal paratest output when no agent is detected', function (): void {
     $process = runWith('paratest', 'PassingTest', withAgent: false);
 
-    expect($process->getOutput())->not->toContain('"result"')
+    expect($process->getOutput())->not->toContain('result: passed')
         ->and($process->getOutput())->toContain('OK');
 });

--- a/tests/Drivers/PestParallelTest.php
+++ b/tests/Drivers/PestParallelTest.php
@@ -113,5 +113,5 @@ it('outputs json for multiple failures and errors', function () use ($extraArgs)
 it('outputs normal pest output when no agent is detected', function () use ($extraArgs): void {
     $process = runWith('pest', 'PassingTest', withAgent: false, extraArgs: $extraArgs);
 
-    expect($process->getOutput())->not->toContain('"result"');
+    expect($process->getOutput())->not->toContain('result: passed');
 });

--- a/tests/Drivers/PestTest.php
+++ b/tests/Drivers/PestTest.php
@@ -111,6 +111,6 @@ it('outputs json for multiple failures and errors', function (): void {
 it('outputs normal pest output when no agent is detected', function (): void {
     $process = runWith('pest', 'PassingTest', withAgent: false);
 
-    expect($process->getOutput())->not->toContain('"result"')
+    expect($process->getOutput())->not->toContain('result: passed')
         ->and($process->getOutput())->toContain('passed');
 });

--- a/tests/Drivers/PhpunitTest.php
+++ b/tests/Drivers/PhpunitTest.php
@@ -90,12 +90,8 @@ it('outputs json for dependent tests', function (): void {
         ->and($output['passed'])->toBe(2);
 });
 
-it('outputs json for tests with unexpected output', function (): void {
-    $process = runWith('phpunit', 'UnexpectedOutputTest');
-    $raw = $process->getOutput();
-
-    $jsonStart = strpos($raw, '{');
-    $output = json_decode(substr($raw, (int) $jsonStart), associative: true, flags: JSON_THROW_ON_ERROR);
+it('outputs toon for tests with unexpected output', function (): void {
+    $output = decodeFromMixedOutput(runWith('phpunit', 'UnexpectedOutputTest'));
 
     expect($output['result'])->toBe('passed')
         ->and($output['tests'])->toBe(1);
@@ -116,6 +112,6 @@ it('outputs json for multiple failures and errors', function (): void {
 it('outputs normal phpunit output when no agent is detected', function (): void {
     $process = runWith('phpunit', 'PassingTest', withAgent: false);
 
-    expect($process->getOutput())->not->toContain('"result"')
+    expect($process->getOutput())->not->toContain('result: passed')
         ->and($process->getOutput())->toContain('OK');
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Pao\Support\ToonDecoder;
 use Symfony\Component\Process\Process;
 
 function runWith(string $binary, string $filter, bool $withAgent = true, array $extraArgs = [], string $config = 'tests/Fixtures/phpunit.xml'): Process
@@ -36,29 +37,22 @@ function decodeFromMixedOutput(Process $process): mixed
 {
     $raw = cleanOutput($process->getOutput());
 
-    $jsonStart = strpos($raw, '{"result":');
+    $toonStart = strpos($raw, 'result: ');
 
-    if ($jsonStart !== false && $jsonStart > 0) {
-        $raw = substr($raw, $jsonStart);
+    if ($toonStart !== false && $toonStart > 0) {
+        $raw = substr($raw, $toonStart);
     }
 
-    return json_decode($raw, associative: true, flags: JSON_THROW_ON_ERROR);
+    return ToonDecoder::decode($raw);
 }
 
 function decodeOutput(Process $process): mixed
 {
     $raw = cleanOutput($process->getOutput());
 
-    $decoded = json_decode($raw, associative: true);
+    $toonStart = strpos($raw, 'result: ');
 
-    if ($decoded === null) {
-        $jsonStart = strpos($raw, '{"result":');
-        if ($jsonStart !== false) {
-            $decoded = json_decode(substr($raw, $jsonStart), associative: true);
-        }
-    }
-
-    if ($decoded === null) {
+    if ($toonStart === false) {
         $stderr = $process->getErrorOutput();
         $exitCode = $process->getExitCode();
         $command = $process->getCommandLine();
@@ -67,7 +61,7 @@ function decodeOutput(Process $process): mixed
         $plugins = file_exists($pluginsFile) ? file_get_contents($pluginsFile) : 'FILE NOT FOUND';
 
         throw new RuntimeException(
-            'Failed to decode JSON: '.json_last_error_msg()."\n".
+            'Failed to find TOON output'."\n".
             sprintf('Command: %s%s', $command, PHP_EOL).
             sprintf('Exit code: %s%s', $exitCode, PHP_EOL).
             sprintf('OS: %s%s', PHP_OS_FAMILY, PHP_EOL).
@@ -77,5 +71,9 @@ function decodeOutput(Process $process): mixed
         );
     }
 
-    return $decoded;
+    if ($toonStart > 0) {
+        $raw = substr($raw, $toonStart);
+    }
+
+    return ToonDecoder::decode($raw);
 }

--- a/tests/Unit/ToonEncoderTest.php
+++ b/tests/Unit/ToonEncoderTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+use Pao\Support\ToonDecoder;
+use Pao\Support\ToonEncoder;
+
+it('encodes passing result', function (): void {
+    $result = [
+        'result' => 'passed',
+        'tests' => 3,
+        'passed' => 3,
+        'duration_ms' => 50,
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toBe(implode("\n", [
+        'result: passed',
+        'tests: 3',
+        'passed: 3',
+        'duration_ms: 50',
+    ]));
+});
+
+it('encodes failing result with failures', function (): void {
+    $result = [
+        'result' => 'failed',
+        'tests' => 2,
+        'passed' => 1,
+        'duration_ms' => 100,
+        'failed' => 1,
+        'failures' => [
+            [
+                'test' => 'Tests\ExampleTest::test_bad',
+                'file' => 'tests/ExampleTest.php',
+                'line' => 15,
+                'message' => 'Failed asserting that false is true.',
+            ],
+        ],
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toContain('result: failed')
+        ->and($toon)->toContain('failed: 1')
+        ->and($toon)->toContain('failures[1]{test,file,line,message}:')
+        ->and($toon)->toContain('Tests\ExampleTest::test_bad,tests/ExampleTest.php,15,Failed asserting that false is true.');
+});
+
+it('encodes error details', function (): void {
+    $result = [
+        'result' => 'failed',
+        'tests' => 1,
+        'passed' => 0,
+        'duration_ms' => 5,
+        'errors' => 1,
+        'error_details' => [
+            [
+                'test' => 'Tests\ErrorTest::test_boom',
+                'file' => 'tests/ErrorTest.php',
+                'line' => 10,
+                'message' => 'RuntimeException: Boom',
+            ],
+        ],
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toContain('errors: 1')
+        ->and($toon)->toContain('error_details[1]{test,file,line,message}:');
+});
+
+it('encodes skipped count', function (): void {
+    $result = [
+        'result' => 'passed',
+        'tests' => 2,
+        'passed' => 1,
+        'duration_ms' => 10,
+        'skipped' => 1,
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toContain('skipped: 1');
+});
+
+it('encodes output lines', function (): void {
+    $result = [
+        'result' => 'passed',
+        'tests' => 1,
+        'passed' => 1,
+        'duration_ms' => 10,
+        'output' => ['Hello from test', 'Another line'],
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toContain('output[2]:')
+        ->and($toon)->toContain(' - Hello from test')
+        ->and($toon)->toContain(' - Another line');
+});
+
+it('escapes messages containing commas', function (): void {
+    $result = [
+        'result' => 'failed',
+        'tests' => 1,
+        'passed' => 0,
+        'duration_ms' => 5,
+        'failed' => 1,
+        'failures' => [
+            [
+                'test' => 'Tests\FailTest::test_bad',
+                'file' => 'tests/FailTest.php',
+                'line' => 42,
+                'message' => 'Expected 1, got 2',
+            ],
+        ],
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toContain('"Expected 1, got 2"');
+});
+
+it('escapes messages containing newlines', function (): void {
+    $result = [
+        'result' => 'failed',
+        'tests' => 1,
+        'passed' => 0,
+        'duration_ms' => 5,
+        'failed' => 1,
+        'failures' => [
+            [
+                'test' => 'Tests\FailTest::test_bad',
+                'file' => 'tests/FailTest.php',
+                'line' => 42,
+                'message' => "Line 1\nLine 2",
+            ],
+        ],
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toContain('"Line 1\nLine 2"');
+});
+
+it('escapes messages containing quotes', function (): void {
+    $result = [
+        'result' => 'failed',
+        'tests' => 1,
+        'passed' => 0,
+        'duration_ms' => 5,
+        'failed' => 1,
+        'failures' => [
+            [
+                'test' => 'Tests\FailTest::test_bad',
+                'file' => 'tests/FailTest.php',
+                'line' => 42,
+                'message' => 'Expected "hello"',
+            ],
+        ],
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toContain('"Expected \\"hello\\""');
+});
+
+it('roundtrips through encoder and decoder', function (): void {
+    $original = [
+        'result' => 'failed',
+        'tests' => 4,
+        'passed' => 1,
+        'duration_ms' => 5234,
+        'failed' => 2,
+        'failures' => [
+            [
+                'test' => 'Tests\MyTest::testA',
+                'file' => '/path/a.php',
+                'line' => 42,
+                'message' => 'Expected true',
+            ],
+            [
+                'test' => 'Tests\MyTest::testB',
+                'file' => '/path/b.php',
+                'line' => 10,
+                'message' => 'Values do not match, expected 1',
+            ],
+        ],
+        'errors' => 1,
+        'error_details' => [
+            [
+                'test' => 'Tests\MyTest::testC',
+                'file' => '/path/c.php',
+                'line' => 7,
+                'message' => 'RuntimeException: Null given',
+            ],
+        ],
+        'skipped' => 1,
+        'output' => ['Debug info here', 'More output'],
+    ];
+
+    $toon = ToonEncoder::encode($original);
+    $decoded = ToonDecoder::decode($toon);
+
+    expect($decoded['result'])->toBe('failed')
+        ->and($decoded['tests'])->toBe(4)
+        ->and($decoded['passed'])->toBe(1)
+        ->and($decoded['duration_ms'])->toBe(5234)
+        ->and($decoded['failed'])->toBe(2)
+        ->and($decoded['failures'])->toHaveCount(2)
+        ->and($decoded['failures'][0]['test'])->toBe('Tests\MyTest::testA')
+        ->and($decoded['failures'][0]['line'])->toBe(42)
+        ->and($decoded['failures'][1]['message'])->toBe('Values do not match, expected 1')
+        ->and($decoded['errors'])->toBe(1)
+        ->and($decoded['error_details'])->toHaveCount(1)
+        ->and($decoded['skipped'])->toBe(1)
+        ->and($decoded['output'])->toBe(['Debug info here', 'More output']);
+});
+
+it('handles empty string values', function (): void {
+    $result = [
+        'result' => 'failed',
+        'tests' => 1,
+        'passed' => 0,
+        'duration_ms' => 5,
+        'failed' => 1,
+        'failures' => [
+            [
+                'test' => 'Tests\FailTest::test_bad',
+                'file' => 'tests/FailTest.php',
+                'line' => 42,
+                'message' => '',
+            ],
+        ],
+    ];
+
+    $toon = ToonEncoder::encode($result);
+
+    expect($toon)->toContain('""');
+});

--- a/tests/Unit/ToonEncoderTest.php
+++ b/tests/Unit/ToonEncoderTest.php
@@ -240,3 +240,40 @@ it('handles empty string values', function (): void {
 
     expect($toon)->toContain('""');
 });
+
+it('decodes toon with blank lines between entries', function (): void {
+    $toon = "result: passed\n\ntests: 2\n   \npassed: 2\nduration_ms: 10";
+
+    $decoded = ToonDecoder::decode($toon);
+
+    expect($decoded['result'])->toBe('passed')
+        ->and($decoded['tests'])->toBe(2)
+        ->and($decoded['passed'])->toBe(2);
+});
+
+it('decodes tabular rows with blank lines between them', function (): void {
+    $toon = "result: failed\ntests: 1\npassed: 0\nduration_ms: 5\nfailed: 1\nfailures[2]{test,file,line,message}:\n Tests\\A::a,a.php,1,Fail\n\n Tests\\B::b,b.php,2,Oops";
+
+    $decoded = ToonDecoder::decode($toon);
+
+    expect($decoded['failures'])->toHaveCount(2)
+        ->and($decoded['failures'][0]['test'])->toBe('Tests\\A::a')
+        ->and($decoded['failures'][1]['test'])->toBe('Tests\\B::b');
+});
+
+it('decodes csv rows with all escape sequences', function (): void {
+    $toon = "result: failed\ntests: 1\npassed: 0\nduration_ms: 5\nfailed: 1\nfailures[1]{test,file,line,message}:\n Tests\\A::a,a.php,1,\"has\\n\\r\\t\\\"\\\\special\\x\"";
+
+    $decoded = ToonDecoder::decode($toon);
+
+    expect($decoded['failures'][0]['message'])->toBe("has\n\r\t\"\\special\\x");
+});
+
+it('decodes output list with quoted values containing escapes', function (): void {
+    $toon = "result: passed\ntests: 1\npassed: 1\nduration_ms: 5\noutput[2]:\n - \"line with\\rnewline\\tand tab\"\n - plain line";
+
+    $decoded = ToonDecoder::decode($toon);
+
+    expect($decoded['output'][0])->toBe("line with\rnewline\tand tab")
+        ->and($decoded['output'][1])->toBe('plain line');
+});


### PR DESCRIPTION
Replaces JSON output with [TOON (Token-Oriented Object Notation)](https://github.com/toon-format/spec), a compact format optimized for LLM consumption that achieves **~40% token reduction over JSON**.

- Scalar fields use simple `key: value` pairs instead of `{"key":"value"}`
- Tabular arrays (failures, errors) declare field names once in a header instead of repeating keys per row
- Output arrays use expanded list format with `- ` prefix
- Custom encoder/decoder with no external dependencies
- Values containing commas, newlines, or quotes are properly escaped per TOON spec

### Before (JSON)
```json
{"result":"failed","tests":2,"passed":1,"duration_ms":100,"failed":1,"failures":[{"test":"Tests\ExampleTest::test_bad","file":"tests/ExampleTest.php","line":15,"message":"Failed asserting that false is true."}]}
```

### After (TOON)
```
result: failed
tests: 2
passed: 1
duration_ms: 100
failed: 1
failures[1]{test,file,line,message}:
 Tests\ExampleTest::test_bad,tests/ExampleTest.php,15,Failed asserting that false is true.
```

## Changes

- `src/Support/ToonEncoder.php` — encodes Result arrays to TOON
- `src/Support/ToonDecoder.php` — decodes TOON back to arrays (used in tests, also useful for consumers)
- Updated all 3 output drivers (Pest, PHPUnit, ParaTest) to use `ToonEncoder::encode()` 
- Updated test helpers (`decodeOutput`, `decodeFromMixedOutput`) to parse TOON
- Updated assertions that checked for JSON markers (`"result"` → `result: passed`)
- Added 10 unit tests for encoder covering: passing, failing, errors, output, escaping, roundtrip

## Test plan

- [x] All 110 existing tests pass
- [x] New ToonEncoder unit tests pass (10 tests)
- [x] Verified TOON output works end-to-end with Pest, PHPUnit, and ParaTest
- [x] Escaping verified for commas, newlines, quotes, and empty strings