### PR TITLE
feat(phpstan): add PHPStan driver for agent-optimized output

### DIFF
--- a/src/Drivers/Phpstan/Starter.php
+++ b/src/Drivers/Phpstan/Starter.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pao\Drivers\Phpstan;
+
+use Pao\Drivers\Starter as BaseStarter;
+use Pao\Execution;
+use Pao\Support\PhpstanParser;
+use Pao\UserFilters\CaptureFilter;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore
+ */
+final class Starter extends BaseStarter
+{
+    public function start(): void
+    {
+        if (! $this->isAnalyseCommand()) {
+            return;
+        }
+
+        $this->registerNullFilter();
+        $this->silenceStderr();
+
+        /** @var array<int, string> $argv */
+        $argv = $_SERVER['argv'];
+        $argv = $this->ensureErrorFormatJson($argv);
+        $argv = $this->ensureNoProgress($argv);
+        $_SERVER['argv'] = $argv;
+
+        $execution = Execution::current();
+        $execution->captureStdout();
+
+        register_shutdown_function(static function (): void {
+            if (! Execution::running()) {
+                return;
+            }
+
+            $execution = Execution::current();
+            $execution->restoreStdout();
+
+            $captured = trim(CaptureFilter::output());
+
+            if ($captured === '') {
+                return;
+            }
+
+            $result = PhpstanParser::parse($captured);
+
+            if ($result === null) {
+                return;
+            }
+
+            fwrite(STDOUT, json_encode($result, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL);
+        });
+    }
+
+    private function isAnalyseCommand(): bool
+    {
+        /** @var array<int, string> $argv */
+        $argv = $_SERVER['argv'] ?? [];
+
+        return in_array('analyse', $argv, true) || in_array('analyze', $argv, true);
+    }
+
+    /**
+     * @param  array<int, string>  $argv
+     * @return array<int, string>
+     */
+    private function ensureErrorFormatJson(array $argv): array
+    {
+        $filtered = [];
+        $skipNext = false;
+
+        foreach ($argv as $arg) {
+            if ($skipNext) {
+                $skipNext = false;
+
+                continue;
+            }
+
+            if (str_starts_with($arg, '--error-format=')) {
+                continue;
+            }
+
+            if ($arg === '--error-format') {
+                $skipNext = true;
+
+                continue;
+            }
+
+            $filtered[] = $arg;
+        }
+
+        $filtered[] = '--error-format=json';
+
+        return $filtered;
+    }
+
+    /**
+     * @param  array<int, string>  $argv
+     * @return array<int, string>
+     */
+    private function ensureNoProgress(array $argv): array
+    {
+        if (! in_array('--no-progress', $argv, true)) {
+            $argv[] = '--no-progress';
+        }
+
+        return $argv;
+    }
+}

--- a/src/Drivers/Starter.php
+++ b/src/Drivers/Starter.php
@@ -29,6 +29,11 @@ abstract class Starter implements Driver
         $execution->filter = stream_filter_append(STDOUT, 'agent_output_null', STREAM_FILTER_WRITE) ?: null;
     }
 
+    protected function silenceStderr(): void
+    {
+        stream_filter_append(STDERR, 'agent_output_null', STREAM_FILTER_WRITE);
+    }
+
     protected function saveStdout(): void
     {
         $execution = Execution::current();

--- a/src/Execution.php
+++ b/src/Execution.php
@@ -52,6 +52,7 @@ final class Execution
         $starter = match ($binary) {
             'paratest' => new Drivers\Paratest\Starter,
             'pest' => new Drivers\Pest\Starter,
+            'phpstan', 'phpstan.phar' => new Drivers\Phpstan\Starter,
             'phpunit' => new Drivers\Phpunit\Starter,
             default => null,
         };

--- a/src/Support/PhpstanParser.php
+++ b/src/Support/PhpstanParser.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pao\Support;
+
+/**
+ * @internal
+ *
+ * @phpstan-type PhpstanErrorDetail array{file: string, line: int, message: string, identifier: string}
+ * @phpstan-type PhpstanResult array{result: 'passed'|'failed', errors: int, error_details?: list<PhpstanErrorDetail>, general_errors?: list<string>}
+ */
+final class PhpstanParser
+{
+    /**
+     * @return PhpstanResult|null
+     */
+    public static function parse(string $json): ?array
+    {
+        // PHPStan may prepend non-JSON lines to stdout (e.g. "Note: Using configuration file ...").
+        // Strip everything before the first '{' so json_decode receives clean input.
+        $start = strpos($json, '{');
+
+        if ($start !== false && $start > 0) {
+            $json = substr($json, $start);
+        }
+
+        /** @var array<string, mixed>|null $data */
+        $data = json_decode($json, associative: true);
+
+        if (! is_array($data) || ! isset($data['totals'])) {
+            return null;
+        }
+
+        /** @var list<PhpstanErrorDetail> $errorDetails */
+        $errorDetails = [];
+
+        /** @var array<string, array{errors: int, messages: list<array{message: string, line: int, ignorable?: bool, identifier?: string, tip?: string}>}> $files */
+        $files = is_array($data['files'] ?? null) ? $data['files'] : [];
+
+        foreach ($files as $file => $fileData) {
+            foreach ($fileData['messages'] as $message) {
+                $errorDetails[] = [
+                    'file' => $file,
+                    'line' => $message['line'],
+                    'message' => $message['message'],
+                    'identifier' => $message['identifier'] ?? 'unknown',
+                ];
+            }
+        }
+
+        /** @var list<string> $errors */
+        $errors = is_array($data['errors'] ?? null) ? $data['errors'] : [];
+
+        /** @var list<string> $generalErrors */
+        $generalErrors = array_values(array_filter($errors, static fn (string $error): bool => $error !== ''));
+
+        $totalErrors = count($errorDetails) + count($generalErrors);
+
+        /** @var PhpstanResult $result */
+        $result = [
+            'result' => $totalErrors > 0 ? 'failed' : 'passed',
+            'errors' => $totalErrors,
+        ];
+
+        if ($errorDetails !== []) {
+            $result['error_details'] = $errorDetails;
+        }
+
+        if ($generalErrors !== []) {
+            $result['general_errors'] = $generalErrors;
+        }
+
+        return $result;
+    }
+}

--- a/tests/Drivers/PhpstanTest.php
+++ b/tests/Drivers/PhpstanTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+it('outputs json for clean code', function (): void {
+    $process = runPhpstan('tests/Fixtures/Phpstan/clean/phpstan.neon');
+
+    $output = decodeOutput($process);
+
+    expect($output['result'])->toBe('passed')
+        ->and($output['errors'])->toBe(0)
+        ->and($output)->not->toHaveKey('error_details')
+        ->and($output)->not->toHaveKey('general_errors');
+});
+
+it('outputs json for code with errors', function (): void {
+    $process = runPhpstan('tests/Fixtures/Phpstan/errors/phpstan.neon');
+
+    $output = decodeOutput($process);
+
+    expect($output['result'])->toBe('failed')
+        ->and($output['errors'])->toBe(2)
+        ->and($output['error_details'])->toHaveCount(2)
+        ->and($output['error_details'][0])->toHaveKeys(['file', 'line', 'message', 'identifier']);
+});
+
+it('includes correct identifiers in error details', function (): void {
+    $process = runPhpstan('tests/Fixtures/Phpstan/errors/phpstan.neon');
+
+    $output = decodeOutput($process);
+
+    $identifiers = array_column($output['error_details'], 'identifier');
+
+    expect($identifiers)->toContain('missingType.return')
+        ->and($identifiers)->toContain('method.notFound');
+});
+
+it('reports correct file path in error details', function (): void {
+    $process = runPhpstan('tests/Fixtures/Phpstan/errors/phpstan.neon');
+
+    $output = decodeOutput($process);
+
+    expect($output['error_details'][0]['file'])->toEndWith('HasErrors.php')
+        ->and($output['error_details'][0]['line'])->toBeGreaterThan(0);
+});
+
+it('passes through normal output without agent', function (): void {
+    $process = runPhpstan('tests/Fixtures/Phpstan/errors/phpstan.neon', withAgent: false);
+
+    $raw = $process->getOutput();
+
+    expect($raw)->not->toContain('"result"')
+        ->and($raw)->toContain('Found 2 errors');
+});

--- a/tests/Fixtures/Phpstan/clean/phpstan.neon
+++ b/tests/Fixtures/Phpstan/clean/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: max
+    paths:
+        - src

--- a/tests/Fixtures/Phpstan/clean/src/Clean.php
+++ b/tests/Fixtures/Phpstan/clean/src/Clean.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Phpstan\Clean;
+
+final class Clean
+{
+    public function greet(string $name): string
+    {
+        return 'Hello, '.$name;
+    }
+}

--- a/tests/Fixtures/Phpstan/errors/phpstan.neon
+++ b/tests/Fixtures/Phpstan/errors/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: max
+    paths:
+        - src

--- a/tests/Fixtures/Phpstan/errors/src/HasErrors.php
+++ b/tests/Fixtures/Phpstan/errors/src/HasErrors.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixtures\Phpstan\Errors;
+
+final class HasErrors
+{
+    public function noReturnType()
+    {
+        return 'hello';
+    }
+
+    public function undefinedMethod(): void
+    {
+        $this->doesNotExist();
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,6 +45,27 @@ function decodeFromMixedOutput(Process $process): mixed
     return json_decode($raw, associative: true, flags: JSON_THROW_ON_ERROR);
 }
 
+function runPhpstan(string $configPath, bool $withAgent = true, array $extraArgs = []): Process
+{
+    $env = [
+        'AI_AGENT' => $withAgent ? '1' : false,
+        'CLAUDECODE' => false,
+        'CLAUDE_CODE' => false,
+    ];
+
+    $command = [PHP_BINARY, 'vendor/bin/phpstan', 'analyse', '--configuration', $configPath, ...$extraArgs];
+
+    $process = new Process(
+        command: $command,
+        cwd: dirname(__DIR__),
+        env: $env,
+    );
+
+    $process->run();
+
+    return $process;
+}
+
 function decodeOutput(Process $process): mixed
 {
     $raw = cleanOutput($process->getOutput());

--- a/tests/Unit/PhpstanParserTest.php
+++ b/tests/Unit/PhpstanParserTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+use Pao\Support\PhpstanParser;
+
+it('returns null for empty string', function (): void {
+    expect(PhpstanParser::parse(''))->toBeNull();
+});
+
+it('returns null for invalid json', function (): void {
+    expect(PhpstanParser::parse('not json'))->toBeNull();
+});
+
+it('returns null for json without totals', function (): void {
+    expect(PhpstanParser::parse('{"foo":"bar"}'))->toBeNull();
+});
+
+it('returns passed for zero errors', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 0, 'file_errors' => 0],
+        'files' => [],
+        'errors' => [],
+    ]);
+
+    $result = PhpstanParser::parse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result['result'])->toBe('passed')
+        ->and($result['errors'])->toBe(0)
+        ->and($result)->not->toHaveKey('error_details')
+        ->and($result)->not->toHaveKey('general_errors');
+});
+
+it('returns failed with error details', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 0, 'file_errors' => 2],
+        'files' => [
+            '/src/Foo.php' => [
+                'errors' => 2,
+                'messages' => [
+                    ['message' => 'No type specified', 'line' => 17, 'ignorable' => true, 'identifier' => 'missingType.parameter'],
+                    ['message' => 'Undefined property', 'line' => 42, 'ignorable' => true, 'identifier' => 'property.notFound'],
+                ],
+            ],
+        ],
+        'errors' => [],
+    ]);
+
+    $result = PhpstanParser::parse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result['result'])->toBe('failed')
+        ->and($result['errors'])->toBe(2)
+        ->and($result['error_details'])->toHaveCount(2)
+        ->and($result['error_details'][0]['file'])->toBe('/src/Foo.php')
+        ->and($result['error_details'][0]['line'])->toBe(17)
+        ->and($result['error_details'][0]['message'])->toBe('No type specified')
+        ->and($result['error_details'][0]['identifier'])->toBe('missingType.parameter')
+        ->and($result['error_details'][1]['identifier'])->toBe('property.notFound');
+});
+
+it('defaults identifier to unknown when missing', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 0, 'file_errors' => 1],
+        'files' => [
+            '/src/Foo.php' => [
+                'errors' => 1,
+                'messages' => [
+                    ['message' => 'Some error', 'line' => 5],
+                ],
+            ],
+        ],
+        'errors' => [],
+    ]);
+
+    $result = PhpstanParser::parse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result['error_details'][0]['identifier'])->toBe('unknown');
+});
+
+it('captures general errors', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 1, 'file_errors' => 0],
+        'files' => [],
+        'errors' => ['Autoload file not found'],
+    ]);
+
+    $result = PhpstanParser::parse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result['result'])->toBe('failed')
+        ->and($result['errors'])->toBe(1)
+        ->and($result['general_errors'])->toBe(['Autoload file not found'])
+        ->and($result)->not->toHaveKey('error_details');
+});
+
+it('combines file errors and general errors', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 1, 'file_errors' => 1],
+        'files' => [
+            '/src/Foo.php' => [
+                'errors' => 1,
+                'messages' => [
+                    ['message' => 'Error', 'line' => 10, 'identifier' => 'return.type'],
+                ],
+            ],
+        ],
+        'errors' => ['General error'],
+    ]);
+
+    $result = PhpstanParser::parse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result['result'])->toBe('failed')
+        ->and($result['errors'])->toBe(2)
+        ->and($result['error_details'])->toHaveCount(1)
+        ->and($result['general_errors'])->toHaveCount(1);
+});
+
+it('discards tip and ignorable fields', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 0, 'file_errors' => 1],
+        'files' => [
+            '/src/Foo.php' => [
+                'errors' => 1,
+                'messages' => [
+                    [
+                        'message' => 'Access to undefined property',
+                        'line' => 35,
+                        'ignorable' => true,
+                        'identifier' => 'property.notFound',
+                        'tip' => 'Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property',
+                    ],
+                ],
+            ],
+        ],
+        'errors' => [],
+    ]);
+
+    $result = PhpstanParser::parse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result['error_details'][0])->toBe([
+            'file' => '/src/Foo.php',
+            'line' => 35,
+            'message' => 'Access to undefined property',
+            'identifier' => 'property.notFound',
+        ]);
+});
+
+it('strips leading non-json content like phpstan note lines', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 0, 'file_errors' => 0],
+        'files' => [],
+        'errors' => [],
+    ]);
+
+    $input = "Note: Using configuration file /home/user/project/phpstan.neon.\n".$json;
+
+    $result = PhpstanParser::parse($input);
+
+    expect($result)->not->toBeNull()
+        ->and($result['result'])->toBe('passed')
+        ->and($result['errors'])->toBe(0);
+});
+
+it('handles multiple files with multiple errors', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 0, 'file_errors' => 3],
+        'files' => [
+            '/src/Foo.php' => [
+                'errors' => 2,
+                'messages' => [
+                    ['message' => 'Error 1', 'line' => 10, 'identifier' => 'return.type'],
+                    ['message' => 'Error 2', 'line' => 20, 'identifier' => 'missingType.parameter'],
+                ],
+            ],
+            '/src/Bar.php' => [
+                'errors' => 1,
+                'messages' => [
+                    ['message' => 'Error 3', 'line' => 5, 'identifier' => 'method.notFound'],
+                ],
+            ],
+        ],
+        'errors' => [],
+    ]);
+
+    $result = PhpstanParser::parse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result['errors'])->toBe(3)
+        ->and($result['error_details'])->toHaveCount(3)
+        ->and($result['error_details'][0]['file'])->toBe('/src/Foo.php')
+        ->and($result['error_details'][2]['file'])->toBe('/src/Bar.php');
+});


### PR DESCRIPTION



## Summary
- Adds a new PHPStan driver that intercepts `analyse` commands, forces `--error-format=json` and `--no-progress`, and converts PHPStan's JSON output into PAO's minimal result schema
- Silences stderr to suppress PHPStan's "Note: Using configuration file ..." messages from leaking into agent output
- Strips leading non-JSON content (e.g. note lines) in `PhpstanParser` before decoding for resilience

<img width="1460" height="753" alt="image" src="https://github.com/user-attachments/assets/e7f87f2a-42dc-4b87-a55d-8b37ac9e815d" />


## Test plan
- [x] Unit tests for `PhpstanParser` covering: empty input, invalid JSON, leading non-JSON prefix, passed/failed results, file errors, general errors, multiple files
- [x] Integration tests in `tests/Drivers/PhpstanTest.php` running PHPStan against clean and error fixtures
- [x] All 116 tests passing
- [x] PHPStan level max passes