### PR TITLE
feat: add memory usage and slow tests detection to JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,33 @@ To this:
   "result": "passed",
   "tests": 1002,
   "passed": 1002,
-  "duration_ms": 321
+  "duration_ms": 321,
+  "memory_mb": 46.5
 }
 ```
 
 🤯 That's up to **99.8% fewer AI tokens**. The output is **constant-size** regardless of how many tests you have — and when tests fail, it includes file paths, line numbers, and failure messages.
+
+When tests are slow, you can identify them by passing a custom threshold (default is `500`ms):
+
+```bash
+vendor/bin/pest --slow-tests-threshold=100
+```
+
+Which adds a `slow_tests` array to the JSON:
+
+```json
+{
+  "result": "passed",
+  "tests": 1002,
+  "passed": 1002,
+  "duration_ms": 1520,
+  "memory_mb": 46.5,
+  "slow_tests": [
+    { "name": "UserTest::it_imports_bulk", "duration_ms": 1240 }
+  ]
+}
+```
 
 Extra output from Pest plugins like `--coverage` or `--profile` is captured, cleaned of ANSI codes and decorations, and included as an `output` array in the JSON:
 
@@ -108,6 +130,7 @@ Extra output from Pest plugins like `--coverage` or `--profile` is captured, cle
   "tests": 1002,
   "passed": 1002,
   "duration_ms": 1520,
+  "memory_mb": 46.5,
   "output": [
     "Http/Controllers/Controller 100.0%",
     "Models/User 0.0%",

--- a/src/Drivers/Paratest/WrapperRunner.php
+++ b/src/Drivers/Paratest/WrapperRunner.php
@@ -38,7 +38,9 @@ final readonly class WrapperRunner implements RunnerInterface
         $execution = Execution::current();
         $execution->restoreStdout();
 
-        $result = $execution->result();
+        $memoryMb = (float) (memory_get_peak_usage(true) / 1024 / 1024);
+
+        $result = $execution->result($memoryMb);
 
         if ($result !== null) {
             $this->output->writeln(json_encode($result, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));

--- a/src/Drivers/Pest/Plugin.php
+++ b/src/Drivers/Pest/Plugin.php
@@ -59,7 +59,9 @@ final class Plugin implements AddsOutput, HandlesArguments, Terminable
 
         $execution = Execution::current();
 
-        $this->result = $execution->result();
+        $memoryMb = (float) (memory_get_peak_usage(true) / 1024 / 1024);
+
+        $this->result = $execution->result($memoryMb);
 
         $execution->captureStdout();
 

--- a/src/Drivers/Phpunit/Subscribers/TestRunnerFinishedSubscriber.php
+++ b/src/Drivers/Phpunit/Subscribers/TestRunnerFinishedSubscriber.php
@@ -27,7 +27,11 @@ final readonly class TestRunnerFinishedSubscriber implements FinishedSubscriber
             return;
         }
 
-        $data = $execution->result();
+        $telemetryInfo = $event->telemetryInfo();
+        $memoryUsage = $telemetryInfo->memoryUsage();
+        $memory = (float) ($memoryUsage->bytes() / 1024 / 1024);
+
+        $data = $execution->result($memory);
 
         if ($data === null) {
             return;

--- a/src/Execution.php
+++ b/src/Execution.php
@@ -17,7 +17,8 @@ use Random\RandomException;
  * @codeCoverageIgnore
  *
  * @phpstan-type TestDetail array{test: string, file: string, line: int, message: string}
- * @phpstan-type Result array{result: 'passed'|'failed', tests: int, passed: int, duration_ms: int, failed?: int, failures?: list<TestDetail>, errors?: int, error_details?: list<TestDetail>, skipped?: int, output?: list<string>}
+ * @phpstan-type SlowTest array{name: string, duration_ms: int}
+ * @phpstan-type Result array{result: 'passed'|'failed', tests: int, passed: int, duration_ms: int, memory_mb: float, slow_tests?: list<SlowTest>, failed?: int, failures?: list<TestDetail>, errors?: int, error_details?: list<TestDetail>, skipped?: int, output?: list<string>}
  */
 final class Execution
 {
@@ -30,6 +31,7 @@ final class Execution
     private function __construct(
         public readonly AgentResult $agent,
         public string $junitFile,
+        public int $slowTestsThreshold = 500,
         public mixed $stdout = null,
         public mixed $filter = null,
     ) {
@@ -47,6 +49,21 @@ final class Execution
             throw new ShouldNotHappenException;
         }
 
+        $slowTestsThreshold = 500;
+        $newArgv = [];
+
+        foreach ($argv as $arg) {
+            if (str_starts_with($arg, '--slow-tests-threshold=')) {
+                $slowTestsThreshold = (int) substr($arg, 23);
+
+                continue;
+            }
+
+            $newArgv[] = $arg;
+        }
+
+        $_SERVER['argv'] = $argv = $newArgv;
+
         $binary = basename($argv[0] ?? '');
 
         $starter = match ($binary) {
@@ -60,6 +77,7 @@ final class Execution
             self::$instance = new self(
                 $agent,
                 sys_get_temp_dir().'/agent-output-'.bin2hex(random_bytes(8)).'.xml',
+                $slowTestsThreshold,
             );
 
             $starter->start();
@@ -127,8 +145,8 @@ final class Execution
     /**
      * @return Result|null
      */
-    public function result(): ?array
+    public function result(float $memoryMb = 0): ?array
     {
-        return JunitParser::parse($this->junitFile);
+        return JunitParser::parse($this->junitFile, $memoryMb, $this->slowTestsThreshold);
     }
 }

--- a/src/Support/JunitParser.php
+++ b/src/Support/JunitParser.php
@@ -10,19 +10,21 @@ use SimpleXMLElement;
  * @internal
  *
  * @phpstan-import-type Result from \Pao\Execution
+ * @phpstan-import-type SlowTest from \Pao\Execution
+ * @phpstan-import-type TestDetail from \Pao\Execution
  */
 final class JunitParser
 {
     /**
      * @return Result|null
      */
-    public static function parse(string $junitFile): ?array
+    public static function parse(string $junitFile, float $memoryMb = 0, int $slowTestsThreshold = 500): ?array
     {
         if (! file_exists($junitFile)) {
             return null;
         }
 
-        $xml = simplexml_load_file($junitFile);
+        $xml = simplexml_load_string((string) file_get_contents($junitFile));
 
         if (! $xml instanceof SimpleXMLElement) {
             return null;
@@ -34,11 +36,14 @@ final class JunitParser
         $skipped = 0;
         $duration = 0.0;
 
-        /** @var list<array{test: string, file: string, line: int, message: string}> $failureDetails */
+        /** @var list<TestDetail> $failureDetails */
         $failureDetails = [];
 
-        /** @var list<array{test: string, file: string, line: int, message: string}> $errorDetails */
+        /** @var list<TestDetail> $errorDetails */
         $errorDetails = [];
+
+        /** @var list<SlowTest> $slowTests */
+        $slowTests = [];
 
         foreach ($xml->testsuite as $suite) {
             $tests += (int) $suite['tests'];
@@ -48,6 +53,15 @@ final class JunitParser
         }
 
         foreach ($xml->xpath('//testcase') ?? [] as $testcase) {
+            $testDurationMs = (int) round((float) $testcase['time'] * 1000);
+
+            if ($testDurationMs > $slowTestsThreshold) {
+                $slowTests[] = [
+                    'name' => $testcase['class'].'::'.$testcase['name'],
+                    'duration_ms' => $testDurationMs,
+                ];
+            }
+
             if (property_exists($testcase, 'skipped') && $testcase->skipped !== null) {
                 $skipped++;
             }
@@ -83,7 +97,12 @@ final class JunitParser
             'tests' => $tests,
             'passed' => $tests - $failures - $errors - $skipped,
             'duration_ms' => (int) round($duration * 1000),
+            'memory_mb' => $memoryMb,
         ];
+
+        if ($slowTests !== []) {
+            $result['slow_tests'] = $slowTests;
+        }
 
         if ($failures > 0) {
             $result['failed'] = $failures;

--- a/tests/Drivers/EdgeCasesTest.php
+++ b/tests/Drivers/EdgeCasesTest.php
@@ -56,7 +56,7 @@ it('does not break when running with process isolation', function (): void {
     $output = decodeOutput(runWith('phpunit', 'PassingTest', extraArgs: ['--process-isolation']));
 
     expect($output['result'])->toBe('passed')
-        ->and($output['tests'])->toBe(2);
+        ->and($output['tests'])->toBe(3);
 });
 
 it('does not break tests that use ob_start', function (): void {

--- a/tests/Drivers/ParatestTest.php
+++ b/tests/Drivers/ParatestTest.php
@@ -6,8 +6,8 @@ it('outputs json for passing tests', function (): void {
     $output = decodeOutput(runWith('paratest', 'PassingTest'));
 
     expect($output['result'])->toBe('passed')
-        ->and($output['tests'])->toBe(2)
-        ->and($output['passed'])->toBe(2)
+        ->and($output['tests'])->toBe(3)
+        ->and($output['passed'])->toBe(3)
         ->and($output)->not->toHaveKey('failed')
         ->and($output)->not->toHaveKey('errors');
 });

--- a/tests/Drivers/PestParallelTest.php
+++ b/tests/Drivers/PestParallelTest.php
@@ -8,8 +8,8 @@ it('outputs json for passing tests', function () use ($extraArgs): void {
     $output = decodeOutput(runWith('pest', 'PassingTest', extraArgs: $extraArgs));
 
     expect($output['result'])->toBe('passed')
-        ->and($output['tests'])->toBe(2)
-        ->and($output['passed'])->toBe(2)
+        ->and($output['tests'])->toBe(3)
+        ->and($output['passed'])->toBe(3)
         ->and($output)->not->toHaveKey('failed')
         ->and($output)->not->toHaveKey('errors');
 });

--- a/tests/Drivers/PestTest.php
+++ b/tests/Drivers/PestTest.php
@@ -6,8 +6,8 @@ it('outputs json for passing tests', function (): void {
     $output = decodeOutput(runWith('pest', 'PassingTest'));
 
     expect($output['result'])->toBe('passed')
-        ->and($output['tests'])->toBe(2)
-        ->and($output['passed'])->toBe(2)
+        ->and($output['tests'])->toBe(3)
+        ->and($output['passed'])->toBe(3)
         ->and($output)->not->toHaveKey('failed')
         ->and($output)->not->toHaveKey('errors');
 });

--- a/tests/Drivers/PhpunitTest.php
+++ b/tests/Drivers/PhpunitTest.php
@@ -1,15 +1,31 @@
 <?php
 
 declare(strict_types=1);
+use Tests\Fixtures\PassingTest;
 
 it('outputs json for passing tests', function (): void {
     $output = decodeOutput(runWith('phpunit', 'PassingTest'));
 
     expect($output['result'])->toBe('passed')
-        ->and($output['tests'])->toBe(2)
-        ->and($output['passed'])->toBe(2)
+        ->and($output['tests'])->toBe(3)
+        ->and($output['passed'])->toBe(3)
+        ->and($output['memory_mb'])->toBeGreaterThan(0)
         ->and($output)->not->toHaveKey('failed')
         ->and($output)->not->toHaveKey('errors');
+});
+
+it('outputs slow tests when threshold is exceeded', function (): void {
+    $output = decodeOutput(runWith('phpunit', 'PassingTest', extraArgs: ['--slow-tests-threshold=100']));
+
+    expect($output['slow_tests'])->toHaveCount(1)
+        ->and($output['slow_tests'][0]['name'])->toBe(PassingTest::class.'::test_it_is_slow')
+        ->and($output['slow_tests'][0]['duration_ms'])->toBeGreaterThanOrEqual(200);
+});
+
+it('omits slow tests when threshold is not exceeded', function (): void {
+    $output = decodeOutput(runWith('phpunit', 'PassingTest', extraArgs: ['--slow-tests-threshold=5000']));
+
+    expect($output)->not->toHaveKey('slow_tests');
 });
 
 it('outputs json for failing tests', function (): void {

--- a/tests/Fixtures/PassingTest.php
+++ b/tests/Fixtures/PassingTest.php
@@ -17,4 +17,10 @@ final class PassingTest extends TestCase
     {
         $this->assertSame('foo', 'foo');
     }
+
+    public function test_it_is_slow(): void
+    {
+        usleep(200000);
+        $this->assertSame('foo', 'foo');
+    }
 }

--- a/tests/Unit/JunitParserTest.php
+++ b/tests/Unit/JunitParserTest.php
@@ -345,3 +345,51 @@ it('falls back to line 0 when message has no file reference', function (): void 
 
     @unlink($file);
 });
+
+it('includes memory_mb in result', function (): void {
+    $file = writeXml('<?xml version="1.0"?>
+    <testsuites>
+      <testsuite name="default" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.001">
+        <testcase name="test_ok" file="tests/OkTest.php" line="5" class="Tests\OkTest" assertions="1" time="0.001"/>
+      </testsuite>
+    </testsuites>');
+
+    $result = JunitParser::parse($file, 46.5);
+
+    expect($result['memory_mb'])->toBe(46.5);
+
+    @unlink($file);
+});
+
+it('includes slow_tests when threshold is exceeded', function (): void {
+    $file = writeXml('<?xml version="1.0"?>
+    <testsuites>
+      <testsuite name="default" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="1.500">
+        <testcase name="test_fast" file="tests/FastTest.php" line="5" class="Tests\FastTest" assertions="1" time="0.100"/>
+        <testcase name="test_slow" file="tests/SlowTest.php" line="5" class="Tests\SlowTest" assertions="1" time="1.400"/>
+      </testsuite>
+    </testsuites>');
+
+    $result = JunitParser::parse($file, 0, 500);
+
+    expect($result['slow_tests'])->toHaveCount(1)
+        ->and($result['slow_tests'][0]['name'])->toBe('Tests\SlowTest::test_slow')
+        ->and($result['slow_tests'][0]['duration_ms'])->toBe(1400);
+
+    @unlink($file);
+});
+
+it('omits slow_tests when none exceed threshold', function (): void {
+    $file = writeXml('<?xml version="1.0"?>
+    <testsuites>
+      <testsuite name="default" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.100">
+        <testcase name="test_fast" file="tests/FastTest.php" line="5" class="Tests\FastTest" assertions="1" time="0.100"/>
+      </testsuite>
+    </testsuites>');
+
+    $result = JunitParser::parse($file, 0, 500);
+
+    expect($result)->not->toHaveKey('slow_tests');
+
+    @unlink($file);
+});


### PR DESCRIPTION
#### Overview
This Pull Request introduces two key features to PAO's JSON output to provide AI agents with better insights during test execution, helping them identify memory leaks and performance bottlenecks.

1.  **Memory Usage (`memory_mb`)**: Reports the peak memory consumed during the test run.
2.  **Slow Tests Detection (`slow_tests`)**: Identifies and lists tests that exceed a configurable duration threshold.

#### Key Changes
-   **New CLI Option**: Added `--slow-tests-threshold=X` (default: 500ms) to define the threshold for slow tests.
-   **Enhanced JSON Output**:
    -   Added `memory_mb` (float) field.
    -   Added `slow_tests` (list of objects with `name` and `duration_ms`) field.
-   **Driver Updates**:
    -   **PHPUnit**: Now uses native telemetry to extract precise memory data from the `Finished` event.
    -   **Pest & Paratest**: Updated to report peak memory usage via `memory_get_peak_usage`.
-   **Static Analysis & Quality**:
    -   Fixed PHPStan errors regarding return types and class resolution.
    -   Improved type management using `@phpstan-import-type` in `JunitParser`.
-   **Documentation**: Updated `README.md` with new benchmarks and JSON output examples.