### PR TITLE
fix: include `--profile` output in JSON result

### DIFF
--- a/src/Drivers/Concerns/JunitParsable.php
+++ b/src/Drivers/Concerns/JunitParsable.php
@@ -58,6 +58,11 @@ trait JunitParsable
             $duration += (float) $suite['time'];
         }
 
+        $profileEnabled = in_array('--profile', $_SERVER['argv'] ?? [], true);
+
+        /** @var list<array{test: string, file: string, duration_ms: int}> $profileEntries */
+        $profileEntries = [];
+
         foreach ($xml->xpath('//testcase') ?? [] as $testcase) {
             if (property_exists($testcase, 'skipped') && $testcase->skipped !== null) {
                 $skipped++;
@@ -86,6 +91,20 @@ trait JunitParsable
                     'message' => $message,
                 ];
             }
+
+            if ($profileEnabled) {
+                $file = (string) $testcase['file'];
+                $doubleColonPos = strpos($file, '::');
+                if ($doubleColonPos !== false) {
+                    $file = substr($file, 0, $doubleColonPos);
+                }
+
+                $profileEntries[] = [
+                    'test' => (string) $testcase['class'].'::'.(string) $testcase['name'],
+                    'file' => $file,
+                    'duration_ms' => (int) round((float) $testcase['time'] * 1000),
+                ];
+            }
         }
 
         /** @var array<string, mixed> $result */
@@ -108,6 +127,11 @@ trait JunitParsable
 
         if ($skipped > 0) {
             $result['skipped'] = $skipped;
+        }
+
+        if ($profileEntries !== []) {
+            usort($profileEntries, fn (array $a, array $b): int => $b['duration_ms'] <=> $a['duration_ms']);
+            $result['profile'] = array_slice($profileEntries, 0, 10);
         }
 
         return $result;

--- a/src/Execution.php
+++ b/src/Execution.php
@@ -15,7 +15,8 @@ use Pao\UserFilters\CaptureFilter;
  * @codeCoverageIgnore
  *
  * @phpstan-type TestDetail array{test: string, file: string, line: int, message: string}
- * @phpstan-type Result array{result: 'passed'|'failed', tests: int, passed: int, duration_ms: int, failed?: int, failures?: list<TestDetail>, errors?: int, error_details?: list<TestDetail>, skipped?: int, raw?: list<string>}
+ * @phpstan-type ProfileEntry array{test: string, file: string, duration_ms: int}
+ * @phpstan-type Result array{result: 'passed'|'failed', tests: int, passed: int, duration_ms: int, failed?: int, failures?: list<TestDetail>, errors?: int, error_details?: list<TestDetail>, skipped?: int, profile?: list<ProfileEntry>, raw?: list<string>}
  */
 final class Execution
 {

--- a/tests/Unit/JunitParserTest.php
+++ b/tests/Unit/JunitParserTest.php
@@ -295,3 +295,69 @@ it('falls back to line 0 when message has no file reference', function (): void 
     expect($result['failures'][0]['file'])->toBe('tests/PestTest.php::it fails')
         ->and($result['failures'][0]['line'])->toBe(0);
 });
+
+it('does not include profile when --profile is not in argv', function (): void {
+    $_SERVER['argv'] = ['pest', '--no-output'];
+
+    $result = junitParse('<?xml version="1.0"?>
+    <testsuites>
+      <testsuite name="default" tests="3" assertions="3" errors="0" failures="0" skipped="0" time="0.050">
+        <testsuite name="Tests\ExampleTest" file="tests/ExampleTest.php" tests="3" assertions="3" errors="0" failures="0" skipped="0" time="0.050">
+          <testcase name="test_one" file="tests/ExampleTest.php" line="10" class="Tests\ExampleTest" assertions="1" time="0.010"/>
+          <testcase name="test_two" file="tests/ExampleTest.php" line="15" class="Tests\ExampleTest" assertions="1" time="0.020"/>
+          <testcase name="test_three" file="tests/ExampleTest.php" line="20" class="Tests\ExampleTest" assertions="1" time="0.020"/>
+        </testsuite>
+      </testsuite>
+    </testsuites>');
+
+    expect($result)->not->toHaveKey('profile');
+});
+
+it('includes profile sorted by duration_ms descending when --profile is in argv', function (): void {
+    $_SERVER['argv'] = ['pest', '--profile'];
+
+    $result = junitParse('<?xml version="1.0"?>
+    <testsuites>
+      <testsuite name="default" tests="4" assertions="4" errors="0" failures="0" skipped="0" time="0.100">
+        <testsuite name="Tests\SlowTest" file="tests/SlowTest.php" tests="4" assertions="4" errors="0" failures="0" skipped="0" time="0.100">
+          <testcase name="test_fast" file="tests/SlowTest.php" line="10" class="Tests\SlowTest" assertions="1" time="0.010"/>
+          <testcase name="test_medium" file="tests/SlowTest.php" line="20" class="Tests\SlowTest" assertions="1" time="0.030"/>
+          <testcase name="test_slow" file="tests/SlowTest.php" line="30" class="Tests\SlowTest" assertions="1" time="0.050"/>
+          <testcase name="test_ok" file="tests/SlowTest.php" line="40" class="Tests\SlowTest" assertions="1" time="0.010"/>
+        </testsuite>
+      </testsuite>
+    </testsuites>');
+
+    expect($result)->toHaveKey('profile')
+        ->and($result['profile'])->toHaveCount(4)
+        ->and($result['profile'][0]['test'])->toBe('Tests\SlowTest::test_slow')
+        ->and($result['profile'][0]['duration_ms'])->toBe(50)
+        ->and($result['profile'][1]['test'])->toBe('Tests\SlowTest::test_medium')
+        ->and($result['profile'][1]['duration_ms'])->toBe(30)
+        ->and($result['profile'][2]['duration_ms'])->toBeGreaterThanOrEqual($result['profile'][3]['duration_ms']);
+});
+
+it('limits profile to top 10 slowest tests', function (): void {
+    $_SERVER['argv'] = ['pest', '--profile'];
+
+    $testcases = '';
+    for ($i = 1; $i <= 15; $i++) {
+        $time = number_format($i * 0.01, 3);
+        $testcases .= "          <testcase name=\"test_{$i}\" file=\"tests/BigTest.php\" line=\"{$i}0\" class=\"Tests\BigTest\" assertions=\"1\" time=\"{$time}\"/>\n";
+    }
+
+    $result = junitParse("<?xml version=\"1.0\"?>
+    <testsuites>
+      <testsuite name=\"default\" tests=\"15\" assertions=\"15\" errors=\"0\" failures=\"0\" skipped=\"0\" time=\"1.200\">
+        <testsuite name=\"Tests\BigTest\" file=\"tests/BigTest.php\" tests=\"15\" assertions=\"15\" errors=\"0\" failures=\"0\" skipped=\"0\" time=\"1.200\">
+{$testcases}        </testsuite>
+      </testsuite>
+    </testsuites>");
+
+    expect($result)->toHaveKey('profile')
+        ->and($result['profile'])->toHaveCount(10)
+        ->and($result['profile'][0]['test'])->toBe('Tests\BigTest::test_15')
+        ->and($result['profile'][0]['duration_ms'])->toBe(150)
+        ->and($result['profile'][9]['test'])->toBe('Tests\BigTest::test_6')
+        ->and($result['profile'][9]['duration_ms'])->toBe(60);
+});


### PR DESCRIPTION
Closes #7

## Problem

When running Pest with the `--profile` flag, PAO only returned the minimal JSON result and omitted the slowest test profile data entirely.

**Before:**
```json
{"result":"passed","tests":116,"passed":116,"duration_ms":16385}
```

## Solution

Parse the `--profile` output from Pest and include it as a `profile` array in the JSON result. Each entry contains the test name, file path, and duration in milliseconds, sorted by slowest tests first.

**After:**
```json
{
  "result": "passed",
  "tests": 116,
  "passed": 116,
  "duration_ms": 16584,
  "profile": [
    {
      "test": "Tests\\Drivers\\PhpstanTest::it outputs json for code with errors",
      "file": "tests/Drivers/PhpstanTest.php",
      "duration_ms": 934
    },
    ...
  ]
}
```