### PR TITLE
Add PAO_FORCE env

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -21,7 +21,7 @@ if (isset($_SERVER['PAO_DISABLE'])) {
 
 $agent = AgentDetector::detect();
 
-if (! $agent->isAgent) {
+if (! $agent->isAgent && ! isset($_SERVER['PAO_FORCE'])) {
     return;
 }
 

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -31,7 +31,7 @@ final class ServiceProvider extends LaravelServiceProvider
             return;
         }
 
-        if (! AgentDetector::detect()->isAgent) {
+        if (! AgentDetector::detect()->isAgent && ! isset($_SERVER['PAO_FORCE'])) {
             return;
         }
 

--- a/tests/Drivers/PestTest.php
+++ b/tests/Drivers/PestTest.php
@@ -118,3 +118,10 @@ it('outputs normal pest output when no agent is detected', function (): void {
     expect($process->getOutput())->not->toContain('"result"')
         ->and($process->getOutput())->toContain('passed');
 });
+
+it('outputs json when PAO_FORCE is set without an agent', function (): void {
+    $output = decodeOutput(runWith('pest', 'PassingTest', withAgent: false, extraEnv: ['PAO_FORCE' => '1']));
+
+    expect($output['result'])->toBe('passed')
+        ->and($output['tests'])->toBe(2);
+});

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -12,7 +12,7 @@ use Tests\Laravel\TestCase;
 uses(TestCase::class);
 
 afterEach(function (): void {
-    unset($_SERVER['AI_AGENT'], $_SERVER['PAO_DISABLE']);
+    unset($_SERVER['AI_AGENT'], $_SERVER['PAO_DISABLE'], $_SERVER['PAO_FORCE']);
     putenv('AI_AGENT');
 });
 

--- a/tests/Laravel/TestCase.php
+++ b/tests/Laravel/TestCase.php
@@ -10,10 +10,11 @@ class TestCase extends BaseTestCase
 {
     protected function setUp(): void
     {
-        unset($_SERVER['AI_AGENT'], $_SERVER['PAO_DISABLE'], $_SERVER['CLAUDE_CODE'], $_SERVER['CLAUDECODE']);
+        unset($_SERVER['AI_AGENT'], $_SERVER['PAO_DISABLE'], $_SERVER['PAO_FORCE'], $_SERVER['CLAUDE_CODE'], $_SERVER['CLAUDECODE']);
         putenv('CLAUDE_CODE');
         putenv('CLAUDECODE');
         putenv('PAO_DISABLE');
+        putenv('PAO_FORCE');
 
         parent::setUp();
     }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,14 +18,14 @@ function buildAgentEnvironment(bool $withAgent = true): array
     return $env;
 }
 
-function runWith(string $binary, string $filter, bool $withAgent = true, array $extraArgs = [], string $config = 'tests/Fixtures/phpunit.xml'): Process
+function runWith(string $binary, string $filter, bool $withAgent = true, array $extraArgs = [], string $config = 'tests/Fixtures/phpunit.xml', array $extraEnv = []): Process
 {
     $command = [PHP_BINARY, 'vendor/bin/'.$binary, '--configuration', $config, '--filter', $filter, ...$extraArgs];
 
     $process = new Process(
         command: $command,
         cwd: dirname(__DIR__),
-        env: buildAgentEnvironment($withAgent),
+        env: array_merge(buildAgentEnvironment($withAgent), $extraEnv),
     );
 
     $process->run();


### PR DESCRIPTION
## Summary
- Add `PAO_FORCE` env to force-enable PAO regardless of agent detection.
- Applied in both `src/Autoload.php` and the Laravel `ServiceProvider`.
- `PAO_DISABLE` still takes precedence as the kill-switch.

## Motivation
When tests run inside a Docker container via `docker compose run --rm`, the host's agent env vars (e.g. Claude Code exports to AI_AGENT its version and model into the shell environment) don't propagate into the container. Enumerating every possible per-agent env var (Claude Code, Cursor, Devin, Gemini CLI, …) in `docker-compose.yml` bloats the compose config, is hard to maintain as new agents appear, and risks overwriting values the agent owns on the host.

`PAO_FORCE=1` lets the container opt into agent-mode output explicitly, without touching host-side variables or shipping a long passthrough list in compose.

## Usage
```bash
docker compose run --rm -e PAO_FORCE=1 app vendor/bin/pest
```