### PR TITLE
Downgrade laravel/agent-detector to version 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "laravel/agent-detector": "^2.0.1"
+        "laravel/agent-detector": "^2.0.0"
     },
     "require-dev": {
         "brianium/paratest": "^7.20.0",


### PR DESCRIPTION
This PR downgrades the laravel/agent-detector package from version ^2.0.1 to ^2.0.0.


---

Reason for Change

The downgrade ensures compatibility with the current project setup and avoids potential issues introduced in newer patch versions.


---

Changes Made

Updated dependency version in composer.json:

"laravel/agent-detector": "^2.0.0"



---

Impact

No breaking changes expected.

Ensures stable behavior aligned with project requirements.

