### PR TITLE
fix: report fatal errors as JSON instead of providing no output

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -33,7 +33,22 @@ unset($_SERVER['COLLISION_PRINTER']);
 $_SERVER['PEST_PARALLEL_NO_OUTPUT'] = '1';
 
 register_shutdown_function(function (): void {
+    $lastError = error_get_last();
+    $hasFatalError = $lastError !== null
+        && in_array($lastError['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR], true);
+
+    $fatalErrorResult = $hasFatalError ? [
+        'result' => 'error',
+        'message' => sprintf('%s in %s on line %d', $lastError['message'], $lastError['file'], $lastError['line']),
+    ] : [];
+
     if (! Execution::running()) {
+        if ($fatalErrorResult !== []) {
+            $binary = basename(($_SERVER['argv'] ?? [])[0] ?? 'unknown');
+
+            fwrite(STDOUT, json_encode(['tool' => $binary] + $fatalErrorResult, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR).PHP_EOL);
+        }
+
         return;
     }
 
@@ -44,6 +59,10 @@ register_shutdown_function(function (): void {
     $captured = trim(UserFilters\CaptureFilter::output());
 
     $execution->restoreStdout();
+
+    if ($result === []) {
+        $result = $fatalErrorResult;
+    }
 
     if ($captured !== '') {
         $captured = OutputCleaner::clean($captured);
@@ -64,7 +83,14 @@ register_shutdown_function(function (): void {
     if ($result !== []) {
         $result = ['tool' => $execution->driver->name()] + $result;
 
-        fwrite(STDOUT, json_encode($result, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR).PHP_EOL);
+        $json = json_encode($result, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR).PHP_EOL;
+
+        while (ob_get_level() > 0) {
+            @ob_end_clean();
+        }
+
+        $stdout = is_resource($execution->stdout) ? $execution->stdout : STDOUT;
+        fwrite($stdout, $json);
     }
 });
 

--- a/tests/Drivers/FatalErrorTest.php
+++ b/tests/Drivers/FatalErrorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+$fatalConfig = 'tests/Fixtures/FatalRedeclaration/phpunit.xml';
+
+it('outputs json with error details when a fatal error occurs during test loading', function () use ($fatalConfig): void {
+    $process = runWith('pest', 'FileATest', config: $fatalConfig, extraEnv: ['PAO_DISABLE' => false]);
+
+    $output = decodeFromMixedOutput($process);
+
+    expect($output['tool'])->toBe('pest')
+        ->and($output['result'])->toBe('error')
+        ->and($output['message'])->toContain('Cannot redeclare')
+        ->and($output['message'])->toContain('myDuplicateHelper');
+});
+
+it('outputs readable error when a fatal error occurs without agent detection', function () use ($fatalConfig): void {
+    $process = runWith('pest', 'FileATest', withAgent: false, config: $fatalConfig, extraEnv: ['PAO_DISABLE' => false]);
+
+    $output = $process->getOutput().$process->getErrorOutput();
+
+    expect($output)->toContain('Cannot redeclare')
+        ->and($output)->toContain('myDuplicateHelper');
+});

--- a/tests/Fixtures/FatalRedeclaration/FileATest.php
+++ b/tests/Fixtures/FatalRedeclaration/FileATest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+function myDuplicateHelper(): string
+{
+    return 'a';
+}
+
+it('uses helper from file A', function (): void {
+    expect(myDuplicateHelper())->toBe('a');
+});

--- a/tests/Fixtures/FatalRedeclaration/FileBTest.php
+++ b/tests/Fixtures/FatalRedeclaration/FileBTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+function myDuplicateHelper(): string
+{
+    return 'b';
+}
+
+it('uses helper from file B', function (): void {
+    expect(myDuplicateHelper())->toBe('b');
+});

--- a/tests/Fixtures/FatalRedeclaration/phpunit.xml
+++ b/tests/Fixtures/FatalRedeclaration/phpunit.xml
@@ -6,8 +6,6 @@
 <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">.</directory>
-            <exclude>./Pest</exclude>
-            <exclude>./FatalRedeclaration</exclude>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
When a PHP fatal error occurs (like a function declaration in multiple test files), pao produces zero output. Just an error code of `255`. This causes issues when an agent is trying to debug the tests, it struggled to find out why the segfault was happening.

While writing some Pest tests this morning, I had accidentally declared a `mrPayload()` helper function in two different test files and while Claude Code was running the tests, it got stuck in a loop trying to figure out the 255 error code. I ran it myself and saw the proper error output.

I thought I'd attempt to upstream a fix to help others with this too. 

### Before (zero output):

```
$ AI_AGENT=1 php vendor/bin/pest --configuration tests/Fixtures/FatalRedeclaration/phpunit.xml
# (nothing — exit code 255)
```
### After:

```
$ AI_AGENT=1 php vendor/bin/pest --configuration tests/Fixtures/FatalRedeclaration/phpunit.xml
{"tool":"pest","result":"error","message":"Cannot redeclare function myDuplicateHelper()... in FileBTest.php on line 5"}
```

