### PR TITLE
Add agent guidance to PHPStan JSON output

### DIFF
--- a/src/Drivers/Phpstan/Starter.php
+++ b/src/Drivers/Phpstan/Starter.php
@@ -113,6 +113,8 @@ final class Starter extends BaseStarter
             } else {
                 $result['error_details'] = $errorDetails;
             }
+
+            $result['instructions'] = $this->agentInstructions();
         }
 
         if ($generalErrors !== []) {
@@ -120,6 +122,24 @@ final class Starter extends BaseStarter
         }
 
         return $result;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function agentInstructions(): array
+    {
+        return [
+            'Each error has an associated identifier, like `argument.type` or `return.missing`.',
+            'Each error identifier has documentation at URL https://phpstan.org/error-identifiers/<identifier>',
+            'This page contains code example, explanation why is this an error and instruction how to fix it.',
+            'Before fixing the error, fetch the documentation page for its identifier.',
+            'The error usually indicates a real bug or incorrect type in the code. Fix the underlying cause, do not just make the error go away.',
+            'Do not add `@phpstan-ignore` comments, `@phpstan-ignore-next-line` comments, or baseline entries to suppress the error.',
+            'Do not use assert() or inline @var PHPDoc tag to override PHPStan\'s inferred type.',
+            'Do not add type casts just to silence errors.',
+            'Do not widen parameter or return types just to make the error go away.',
+        ];
     }
 
     /**

--- a/src/Drivers/Phpstan/Starter.php
+++ b/src/Drivers/Phpstan/Starter.php
@@ -124,22 +124,11 @@ final class Starter extends BaseStarter
         return $result;
     }
 
-    /**
-     * @return list<string>
-     */
-    private function agentInstructions(): array
+    private function agentInstructions(): string
     {
-        return [
-            'Each error has an associated identifier, like `argument.type` or `return.missing`.',
-            'Each error identifier has documentation at URL https://phpstan.org/error-identifiers/<identifier>',
-            'This page contains code example, explanation why is this an error and instruction how to fix it.',
-            'Before fixing the error, fetch the documentation page for its identifier.',
-            'The error usually indicates a real bug or incorrect type in the code. Fix the underlying cause, do not just make the error go away.',
-            'Do not add `@phpstan-ignore` comments, `@phpstan-ignore-next-line` comments, or baseline entries to suppress the error.',
-            'Do not use assert() or inline @var PHPDoc tag to override PHPStan\'s inferred type.',
-            'Do not add type casts just to silence errors.',
-            'Do not widen parameter or return types just to make the error go away.',
-        ];
+        return <<<'TXT'
+            Each error has an associated identifier, like `argument.type` or `return.missing`. Each error identifier has documentation at URL https://phpstan.org/error-identifiers/<identifier>, which contains a code example, explanation why it is an error, and instructions on how to fix it. Before fixing the error, fetch the documentation page for its identifier. The error usually indicates a real bug or incorrect type in the code. Fix the underlying cause, do not just make the error go away. Do not add `@phpstan-ignore` comments, `@phpstan-ignore-next-line` comments, or baseline entries to suppress the error. Do not use assert() or inline @var PHPDoc tag to override PHPStan's inferred type. Do not add type casts just to silence errors. Do not widen parameter or return types just to make the error go away.
+            TXT;
     }
 
     /**

--- a/tests/Unit/PhpstanParserTest.php
+++ b/tests/Unit/PhpstanParserTest.php
@@ -52,7 +52,44 @@ it('returns passed for zero errors', function (): void {
         ->and($result['result'])->toBe('passed')
         ->and($result['errors'])->toBe(0)
         ->and($result)->not->toHaveKey('error_details')
-        ->and($result)->not->toHaveKey('general_errors');
+        ->and($result)->not->toHaveKey('general_errors')
+        ->and($result)->not->toHaveKey('instructions');
+});
+
+it('includes agent instructions when file errors are present', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 0, 'file_errors' => 1],
+        'files' => [
+            '/src/Foo.php' => [
+                'errors' => 1,
+                'messages' => [
+                    ['message' => 'Some error', 'line' => 5, 'identifier' => 'return.type'],
+                ],
+            ],
+        ],
+        'errors' => [],
+    ]);
+
+    $result = phpstanParse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result)->toHaveKey('instructions')
+        ->and($result['instructions'])->toBeArray()
+        ->and($result['instructions'][0])->toContain('identifier')
+        ->and($result['instructions'])->toContain('Do not add type casts just to silence errors.');
+});
+
+it('does not include instructions for general errors only', function (): void {
+    $json = (string) json_encode([
+        'totals' => ['errors' => 1, 'file_errors' => 0],
+        'files' => [],
+        'errors' => ['Autoload file not found'],
+    ]);
+
+    $result = phpstanParse($json);
+
+    expect($result)->not->toBeNull()
+        ->and($result)->not->toHaveKey('instructions');
 });
 
 it('returns failed with error details', function (): void {

--- a/tests/Unit/PhpstanParserTest.php
+++ b/tests/Unit/PhpstanParserTest.php
@@ -74,8 +74,8 @@ it('includes agent instructions when file errors are present', function (): void
 
     expect($result)->not->toBeNull()
         ->and($result)->toHaveKey('instructions')
-        ->and($result['instructions'])->toBeArray()
-        ->and($result['instructions'][0])->toContain('identifier')
+        ->and($result['instructions'])->toBeString()
+        ->and($result['instructions'])->toContain('Each error has an associated identifier')
         ->and($result['instructions'])->toContain('Do not add type casts just to silence errors.');
 });
 


### PR DESCRIPTION
When PHPStan runs in agent mode it appends an "Instructions for interpreting errors" block to its console output (see [AnalyseCommand.php#L583](https://github.com/phpstan/phpstan-src/blob/2.2.x/src/Command/AnalyseCommand.php#L583)), telling the agent to fetch the identifier docs, not suppress with `@phpstan-ignore` or baselines, not override types with `assert()` / `@var` / casts, etc. PAO's JSON output was missing this, so agents had no equivalent steer.

This PR adds an `instructions` field to the JSON result whenever there are file-specific errors:

```json
{
  "tool": "phpstan",
  "result": "failed",
  "errors": 3,
  "error_details": { ... },
  "instructions": "Each error has an associated identifier... Do not add `@phpstan-ignore` comments... Do not widen parameter or return types just to make the error go away."
}
```