### PR TITLE
Report no matching Pest tests as failed

### DIFF
--- a/src/Drivers/Concerns/TestResultParsable.php
+++ b/src/Drivers/Concerns/TestResultParsable.php
@@ -125,6 +125,7 @@ trait TestResultParsable
         $notices = $testResult->numberOfNotices();
         $risky = $testResult->numberOfTestsWithTestConsideredRiskyEvents();
         $ignoredByBaseline = $testResult->numberOfIssuesIgnoredByBaseline();
+        $hasNoTests = $tests === 0;
 
         $durationMs = ProfileCollector::durationMs();
 
@@ -172,12 +173,16 @@ trait TestResultParsable
 
         /** @var array<string, mixed> $result */
         $result = [
-            'result' => $testResult->wasSuccessful() ? 'passed' : 'failed',
+            'result' => $testResult->wasSuccessful() && ! $hasNoTests ? 'passed' : 'failed',
             'tests' => $tests,
             'passed' => $tests - $failedCount - $erroredCount - $skipped,
             'assertions' => $assertions,
             'duration_ms' => $durationMs,
         ];
+
+        if ($hasNoTests) {
+            $result['raw'] = ['No tests found.'];
+        }
 
         if ($failedCount > 0) {
             $result['failed'] = $failedCount;

--- a/tests/Drivers/PestTest.php
+++ b/tests/Drivers/PestTest.php
@@ -76,6 +76,19 @@ it('outputs json for risky tests', function (): void {
         ->and($output['risky'])->toBe(1);
 });
 
+it('outputs failed json when no pest tests match', function (): void {
+    $process = runWith('pest', 'definitely no matching test', config: 'tests/Fixtures/Pest/phpunit.xml');
+
+    expect($process->getExitCode())->not->toBe(0);
+
+    $output = decodeOutput($process);
+
+    expect($output['result'])->toBe('failed')
+        ->and($output['tests'])->toBe(0)
+        ->and($output['passed'])->toBe(0)
+        ->and($output['raw'])->toContain('No tests found.');
+});
+
 it('outputs json for data provider tests', function (): void {
     $output = decodeOutput(runWith('pest', 'DataProviderTest'));
 


### PR DESCRIPTION
## Summary
- Treat Pest runs that execute zero tests as failed PAO results
- Include a raw "No tests found." diagnostic so agents can see why verification failed
- Add regression coverage for a filter that matches no Pest tests

Fixes #28.

## Verification
- vendor/bin/pest tests/Drivers/PestTest.php --filter 'outputs failed json when no pest tests match'
- vendor/bin/pest tests/Drivers/PestTest.php
- vendor/bin/pest tests/Drivers/EdgeCasesTest.php
- vendor/bin/pint --test
- git diff --check

Note: vendor/bin/phpstan analyse currently fails on an existing method.notFound issue around PHPUnit failed-event types in TestResultParsable.php. The broader vendor/bin/pest tests/Drivers run also hits local PHPStan/Rector fixture environment failures unrelated to this change.