### PR TITLE
Refactor condition to use null coalescing operator

### DIFF
--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -31,7 +31,7 @@ final class ServiceProvider extends LaravelServiceProvider
             return;
         }
 
-        if (! AgentDetector::detect()->isAgent && ! isset($_SERVER['PAO_FORCE'])) {
+        if (! AgentDetector::detect()->isAgent && ! ($_SERVER['PAO_FORCE'] ?? false)) {
             return;
         }
 


### PR DESCRIPTION
## Summary

Updated the `PAO_FORCE` check in `src/Laravel/ServiceProvider.php` to evaluate the flag's value rather than only checking for its presence.

## Changes

- Replaced:
  ```php
  isset($_SERVER['PAO_FORCE'])

- With
   ```php
  ($_SERVER['PAO_FORCE'] ?? false)