### PR TITLE
Enable Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,12 @@
+name: dependabot-auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    uses: laravel/.github/.github/workflows/dependabot-auto-merge.yml@b5f0b1a7206f5f4feedb66864e4db687e1f8d8ff


### PR DESCRIPTION
Adds a thin workflow that calls the shared reusable `dependabot-auto-merge` workflow in `laravel/.github` (pinned by commit SHA) to auto-merge this repo's grouped Dependabot `github-actions` PRs once required CI passes. Patch and minor bumps only; majors stay open for review.