### PR TITLE
Fix parallel coverage JSON result

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -61,6 +61,11 @@ register_shutdown_function(function (): void {
             $existing = is_array($result['raw'] ?? null) ? array_values($result['raw']) : [];
 
             $result['raw'] = [...$existing, ...$lines];
+
+            if (($result['result'] ?? null) === 'passed'
+                && in_array('ERROR No code coverage driver is available.', $lines, true)) {
+                $result['result'] = 'failed';
+            }
         }
     }
 

--- a/tests/Drivers/PestParallelTest.php
+++ b/tests/Drivers/PestParallelTest.php
@@ -116,3 +116,18 @@ it('outputs normal pest output when no agent is detected', function () use ($ext
 
     expect($process->getOutput())->not->toContain('"result"');
 });
+
+it('outputs failed json when parallel coverage cannot start without a driver', function (): void {
+    $process = runWith('pest', 'PassingTest', extraArgs: ['--parallel', '--coverage', '--min=100'], extraEnv: [
+        'XDEBUG_MODE' => 'coverage',
+    ]);
+
+    expect($process->getExitCode())->not->toBe(0);
+
+    $output = decodeOutput($process);
+
+    expect($output['result'])->toBe('failed')
+        ->and($output['tests'])->toBe(0)
+        ->and($output['passed'])->toBe(0)
+        ->and($output['raw'])->toContain('ERROR No code coverage driver is available.');
+});


### PR DESCRIPTION
Fixes #37.

When a parallel Pest coverage run reports that no coverage driver is available,
the command exits non-zero but Pao can still synthesize JSON with
`"result":"passed"` and zero tests. This treats that coverage-driver error in
the captured raw output as a failed result so the JSON matches the command
failure.

Validation:

```sh
docker run --rm -v "$PWD":/app -w /app php:8.4-cli sh -lc 'AI_AGENT=1 XDEBUG_MODE=coverage php vendor/bin/pest --configuration tests/Fixtures/phpunit.xml --filter PassingTest --parallel --coverage --min=100; printf "\nexit=%s\n" "$?"'
# {"tool":"pest","result":"failed","tests":0,"passed":0,"assertions":0,...,"raw":["No tests found.","ERROR No code coverage driver is available."]}
# exit=1

docker run --rm -v "$PWD":/app -w /app php:8.4-cli php vendor/bin/pest tests/Drivers/PestParallelTest.php
# PASS Tests\Drivers\PestParallelTest
# Tests: 15 passed (48 assertions)

../../scripts/oss-factory-pre-push-check.sh
# OK: oss-factory pre-push checks passed
```
