### PR TITLE
[1.x] Fixes exit code 1 when the caller already passes output flags on Pest 5

### DIFF
--- a/src/Drivers/Pest/Plugin.php
+++ b/src/Drivers/Pest/Plugin.php
@@ -29,8 +29,11 @@ final class Plugin implements HandlesArguments
             return $arguments;
         }
 
-        $arguments[] = '--no-output';
-        $arguments[] = '--no-progress';
+        foreach (['--no-output', '--no-progress'] as $flag) {
+            if (! in_array($flag, $arguments, true)) {
+                $arguments[] = $flag;
+            }
+        }
 
         return $arguments;
     }

--- a/tests/Drivers/PestTest.php
+++ b/tests/Drivers/PestTest.php
@@ -145,3 +145,14 @@ it('outputs normal pest output when PAO_FORCE is falsy without an agent', functi
     expect($process->getOutput())->not->toContain('"result"')
         ->and($process->getOutput())->toContain('passed');
 })->with(['0', 'false']);
+
+it('keeps a passing exit code when the caller already passes the output flags', function (): void {
+    $process = runWith('pest', 'PassingTest', extraArgs: ['--no-output', '--no-progress']);
+
+    expect($process->getExitCode())->toBe(0);
+
+    $output = decodeOutput($process);
+
+    expect($output['result'])->toBe('passed')
+        ->and($output['tests'])->toBe(2);
+});


### PR DESCRIPTION
## Summary

With pao active (agent detected), every `php artisan test` run on Pest 5 exits with code 1 even when the whole suite passes. The JSON summary still reports `"result": "passed"` — only the exit code is wrong, so wrappers like `composer test` scripts and CI report failure on green suites.

## Root cause

Collision's `artisan test` command already passes `--no-output` to the Pest subprocess it spawns. pao's Pest plugin then unconditionally appends `--no-output` and `--no-progress` on top:

```php
$arguments[] = '--no-output';
$arguments[] = '--no-progress';
```

so the child process receives the flag twice. Pest 4 tolerated the duplicate; Pest 5 (on PHPUnit 13's CLI handling) exits non-zero when the same option is provided twice. The duplication is reproducible without pao at all:

```bash
vendor/bin/pest --no-output --no-output   # exits 1, all tests pass
```

Tests run and pass either way; the failure is purely the exit code.

## Why the suite didn't catch it

pao's existing Pest driver tests invoke `vendor/bin/pest` without any output flags, so the plugin only ever adds the first (and only) `--no-output`. Nothing exercised the `artisan test` shape where the caller supplies the flag itself.

## The fix

The plugin now only appends flags the caller has not already provided. Includes a regression test that reproduces the `artisan test` invocation (`extraArgs: ['--no-output', '--no-progress']`) and asserts exit code 0 — it fails with `Failed asserting that 1 is identical to 0` before the fix.

## Steps to reproduce

Any Laravel project on Pest 5 with pao active:

```bash
AI_AGENT=1 php artisan test   # exit 1, JSON reports passed
```