### PR TITLE
Do not repeat output flags the caller already passed

### DIFF
--- a/src/Drivers/Pest/Plugin.php
+++ b/src/Drivers/Pest/Plugin.php
@@ -29,8 +29,13 @@ final class Plugin implements HandlesArguments
             return $arguments;
         }
 
-        $arguments[] = '--no-output';
-        $arguments[] = '--no-progress';
+        if (! in_array('--no-output', $arguments, true)) {
+            $arguments[] = '--no-output';
+        }
+
+        if (! in_array('--no-progress', $arguments, true)) {
+            $arguments[] = '--no-progress';
+        }
 
         return $arguments;
     }

--- a/tests/Drivers/PestTest.php
+++ b/tests/Drivers/PestTest.php
@@ -145,3 +145,10 @@ it('outputs normal pest output when PAO_FORCE is falsy without an agent', functi
     expect($process->getOutput())->not->toContain('"result"')
         ->and($process->getOutput())->toContain('passed');
 })->with(['0', 'false']);
+
+it('does not repeat an output flag the caller already passed', function (string $flag): void {
+    $process = runWith('pest', 'PassingTest', extraArgs: [$flag]);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(decodeOutput($process)['result'])->toBe('passed');
+})->with(['--no-output', '--no-progress']);


### PR DESCRIPTION
## The bug

`php artisan test` exits **1** on a fully passing suite whenever an agent environment is detected — while printing `"result":"passed"`.

```
$ CLAUDECODE=1 php artisan test
{"tool":"pest","result":"passed","tests":121,"passed":121,"assertions":535,"duration_ms":10430}
$ echo $?
1
```

Collision's `TestCommand` always prepends `--no-output` to the Pest subprocess ([TestCommand.php#L215](https://github.com/nunomaduro/collision/blob/8.x/src/Adapters/Laravel/Commands/TestCommand.php#L215)). The Pest driver then appends `--no-output` and `--no-progress` unconditionally, so the runner receives `--no-output` twice.

PHPUnit answers a repeated flag with a test-runner warning — from the verbose event log:

```
Test Runner Triggered PHPUnit Warning (Option --no-output cannot be used more than once)
```

`failOnPhpunitWarning` defaults to true, so Pest exits 1 *after* every test has run and been reported as passed, and Collision passes that code straight through.

The practical damage: `composer test` and CI report red on a green tree, and an agent has no way to tell this false red from a real failure. `--no-progress` reproduces it identically, with no duplication from Collision involved:

```
pest --no-output   --filter=PassingTest                  # exit 0
pest --no-output   --no-output   --filter=PassingTest    # exit 1
pest --no-progress --no-progress --filter=PassingTest    # exit 1
```

## The fix

Guard both appends. This is what pao already does everywhere else — `Drivers/Phpunit/Starter.php#L36` and `Drivers/Phpstan/Starter.php#L211` both check `in_array(...)` first — and what Pest's own `Pest\Plugins\Printer` does. Only the Pest driver was missing the guard.

## Tests

One case added to `tests/Drivers/PestTest.php`, using the existing `runWith()` helper. It fails 2/2 with the `src/` change reverted and passes with it applied. `composer test` is green (rector, pint, type coverage, phpstan, 20 Pest tests).