### PR TITLE
feat(laravel): guard destructive commands from agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ When installed in a Laravel 12+ application, PAO automatically cleans Artisan co
 
 Up to **75% fewer tokens** on commands like `about`, `db:show`, and `migrate:status` — same information, no decoration.
 
+### Guarding Destructive Commands
+
+When PAO detects an agent, it automatically **blocks destructive database commands** — `migrate:fresh`, `migrate:refresh`, `migrate:reset`, `migrate:rollback`, and `db:wipe` — so an agent can't accidentally wipe your database. The command exits with a failure and warns the agent:
+
+```
+That is a dangerous command and has not been executed. Ask the user to run it manually, then continue.
+```
+
+This keeps humans in control of irreversible operations. The guard runs *before* the command does anything, ignores `--force`, and also covers the nested `db:wipe` call that `migrate:fresh` makes internally.
+
+If you legitimately want an agent to run these (for example, an ephemeral CI database), opt out with the `PAO_GUARD_DISABLE` environment variable:
+
+```bash
+PAO_GUARD_DISABLE=1 php artisan migrate:fresh
+```
+
+> **Note:** The guard only activates when an agent is detected, and it is disabled entirely during your own test suite (so traits like `RefreshDatabase`, which call `migrate:fresh`, keep working).
+
 ### PHPStan
 
 PHPStan output is also converted to structured JSON:

--- a/src/Laravel/DestructiveCommandGuard.php
+++ b/src/Laravel/DestructiveCommandGuard.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Pao\Laravel;
+
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * @internal
+ */
+final readonly class DestructiveCommandGuard
+{
+    /**
+     * @var list<string>
+     */
+    public const array GUARDED_COMMANDS = [
+        'migrate:fresh',
+        'migrate:refresh',
+        'migrate:reset',
+        'migrate:rollback',
+        'db:wipe',
+    ];
+
+    public function __construct(private Dispatcher $events) {}
+
+    public function activate(): void
+    {
+        DB::prohibitDestructiveCommands(true);
+
+        $this->events->listen(CommandStarting::class, function (CommandStarting $event): void {
+            if (in_array($event->command, self::GUARDED_COMMANDS, true)) {
+                $event->output->writeln('<fg=yellow>'.$this->message().'</>');
+            }
+        });
+    }
+
+    public function message(): string
+    {
+        return 'That is a dangerous command and has not been executed. Ask the user to run it manually, then continue.';
+    }
+}

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -31,6 +31,10 @@ final class ServiceProvider extends LaravelServiceProvider
             return;
         }
 
+        if ($this->shouldGuardDestructiveCommands()) {
+            $this->app->make(DestructiveCommandGuard::class)->activate();
+        }
+
         if (! AgentDetector::detect()->isAgent && ! filter_var($_SERVER['PAO_FORCE'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
             return;
         }
@@ -42,5 +46,14 @@ final class ServiceProvider extends LaravelServiceProvider
         $events->listen(CommandStarting::class, function (CommandStarting $event): void {
             $event->output->setDecorated(false);
         });
+    }
+
+    private function shouldGuardDestructiveCommands(): bool
+    {
+        if (! AgentDetector::detect()->isAgent && ! filter_var($_SERVER['PAO_FORCE'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
+            return false;
+        }
+
+        return ! filter_var($_SERVER['PAO_GUARD_DISABLE'] ?? false, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/tests/Laravel/DestructiveCommandGuardTest.php
+++ b/tests/Laravel/DestructiveCommandGuardTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Console\Migrations\FreshCommand;
+use Illuminate\Database\Console\Migrations\RefreshCommand;
+use Illuminate\Database\Console\Migrations\ResetCommand;
+use Illuminate\Database\Console\Migrations\RollbackCommand;
+use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Support\Facades\DB;
+use Laravel\Pao\Laravel\DestructiveCommandGuard;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\Laravel\TestCase;
+
+uses(TestCase::class);
+
+afterEach(function (): void {
+    DB::prohibitDestructiveCommands(false);
+});
+
+it('prohibits all five destructive commands', function (): void {
+    app()->make(DestructiveCommandGuard::class)->activate();
+
+    foreach ([
+        FreshCommand::class,
+        RefreshCommand::class,
+        ResetCommand::class,
+        RollbackCommand::class,
+        WipeCommand::class,
+    ] as $command) {
+        expect(prohibitedFlag($command))->toBeTrue();
+    }
+});
+
+it('writes the guidance message when a guarded command starts', function (): void {
+    $output = new BufferedOutput;
+
+    app()->make(DestructiveCommandGuard::class)->activate();
+
+    /** @var Dispatcher $dispatcher */
+    $dispatcher = app(Dispatcher::class);
+    $dispatcher->dispatch(new CommandStarting('migrate:fresh', new ArrayInput([]), $output));
+
+    expect($output->fetch())->toContain('Ask the user to run it manually');
+});
+
+it('does not write the message for unrelated commands', function (): void {
+    $output = new BufferedOutput;
+
+    app()->make(DestructiveCommandGuard::class)->activate();
+
+    /** @var Dispatcher $dispatcher */
+    $dispatcher = app(Dispatcher::class);
+    $dispatcher->dispatch(new CommandStarting('migrate:status', new ArrayInput([]), $output));
+
+    expect($output->fetch())->toBe('');
+});
+
+it('exposes the full list of guarded command names', function (): void {
+    expect(DestructiveCommandGuard::GUARDED_COMMANDS)->toBe([
+        'migrate:fresh',
+        'migrate:refresh',
+        'migrate:reset',
+        'migrate:rollback',
+        'db:wipe',
+    ]);
+});
+
+it('returns the guidance message', function (): void {
+    expect(app()->make(DestructiveCommandGuard::class)->message())
+        ->toContain('dangerous command')
+        ->toContain('Ask the user to run it manually');
+});
+
+function prohibitedFlag(string $commandClass): bool
+{
+    $property = (new ReflectionClass($commandClass))->getProperty('prohibitedFromRunning');
+    $property->setAccessible(true);
+
+    return (bool) $property->getValue();
+}

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -12,8 +12,9 @@ use Tests\Laravel\TestCase;
 uses(TestCase::class);
 
 afterEach(function (): void {
-    unset($_SERVER['AI_AGENT'], $_SERVER['PAO_DISABLE'], $_SERVER['PAO_FORCE']);
+    unset($_SERVER['AI_AGENT'], $_SERVER['PAO_DISABLE'], $_SERVER['PAO_FORCE'], $_SERVER['PAO_GUARD_DISABLE']);
     putenv('AI_AGENT');
+    putenv('PAO_GUARD_DISABLE');
 });
 
 it('does not bind PaoOutputStyle when not in agent mode', function (): void {
@@ -36,3 +37,28 @@ it('does not bind PaoOutputStyle when PAO_DISABLE is set', function (): void {
         'output' => new NullOutput,
     ]))->not->toBeInstanceOf(PaoOutputStyle::class);
 });
+
+it('does not guard destructive commands when no agent is detected', function (): void {
+    expect(shouldGuardDestructiveCommands(new ServiceProvider($this->app)))->toBeFalse();
+});
+
+it('guards destructive commands when an agent is detected', function (): void {
+    putenv('AI_AGENT=1');
+
+    expect(shouldGuardDestructiveCommands(new ServiceProvider($this->app)))->toBeTrue();
+});
+
+it('does not guard destructive commands when PAO_GUARD_DISABLE is set', function (): void {
+    putenv('AI_AGENT=1');
+    $_SERVER['PAO_GUARD_DISABLE'] = '1';
+
+    expect(shouldGuardDestructiveCommands(new ServiceProvider($this->app)))->toBeFalse();
+});
+
+function shouldGuardDestructiveCommands(ServiceProvider $provider): bool
+{
+    $method = (new ReflectionClass($provider))->getMethod('shouldGuardDestructiveCommands');
+    $method->setAccessible(true);
+
+    return (bool) $method->invoke($provider);
+}

--- a/tests/Laravel/TestCase.php
+++ b/tests/Laravel/TestCase.php
@@ -4,17 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Laravel;
 
+use Laravel\AgentDetector\AgentDetector;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
     protected function setUp(): void
     {
-        unset($_SERVER['AI_AGENT'], $_SERVER['PAO_DISABLE'], $_SERVER['PAO_FORCE'], $_SERVER['CLAUDE_CODE'], $_SERVER['CLAUDECODE']);
-        putenv('CLAUDE_CODE');
-        putenv('CLAUDECODE');
+        foreach (array_keys(AgentDetector::AGENT_ENV_VARS) as $envVar) {
+            unset($_SERVER[$envVar]);
+            putenv($envVar);
+        }
+
+        unset($_SERVER['AI_AGENT'], $_SERVER['PAO_DISABLE'], $_SERVER['PAO_FORCE'], $_SERVER['PAO_GUARD_DISABLE']);
+        putenv('AI_AGENT');
         putenv('PAO_DISABLE');
         putenv('PAO_FORCE');
+        putenv('PAO_GUARD_DISABLE');
 
         parent::setUp();
     }


### PR DESCRIPTION
## Summary

When PAO detects an AI agent, it now **blocks destructive database commands** so an agent can't accidentally wipe a database. The following commands are guarded:

- `migrate:fresh`
- `migrate:refresh`
- `migrate:reset`
- `migrate:rollback`
- `db:wipe`

When an agent attempts one of these, the command exits with a failure **before doing anything** and the agent is warned:

<img width="865" height="153" alt="image" src="https://github.com/user-attachments/assets/a795f180-06ee-4d07-a227-98bda6827092" />

This keeps humans in control of irreversible operations while leaving all other Artisan output cleaning untouched.

## Opting out

Legitimate agent-driven flows (e.g. an ephemeral CI database) can opt out with the `PAO_GUARD_DISABLE` environment variable, following the existing `PAO_DISABLE`/`PAO_FORCE` convention:

```bash
PAO_GUARD_DISABLE=1 php artisan migrate:fresh
```

## How it works

- The abort uses the framework's existing `Prohibitable` mechanism via `DB::prohibitDestructiveCommands(true)` — a static flag set during the provider `boot()`, guaranteed to run before `handle()`. This is the only abort path with no provider-ordering risk.
- Because `Prohibitable` ignores `--force`, agents passing `--force` are still blocked. It also covers the nested `db:wipe` call that `migrate:fresh` makes internally.
- The agent-facing guidance is emitted via a `CommandStarting` listener (the existing `Prohibitable` message is generic, so a dedicated message is added alongside it).
- The guard is **disabled during the test suite** (`runningUnitTests()`), so traits like `RefreshDatabase`/`DatabaseTruncation` — which call `migrate:fresh` — keep working.

## Checklist

- [x] 100% coverage on new code (PAO enforces `--exactly=100`)
- [x] `pint`, `phpstan`, `rector --dry-run` clean
- [x] No new dependencies (uses existing `laravel/agent-detector` + framework `Prohibitable`)