### PR TITLE
Support new TestResult constructor arguments on PHPUnit 13.3

### DIFF
--- a/src/Drivers/Paratest/WrapperRunner.php
+++ b/src/Drivers/Paratest/WrapperRunner.php
@@ -154,11 +154,45 @@ final readonly class WrapperRunner implements RunnerInterface
                 $sum->numberOfIssuesIgnoredByBaseline() + $testResult->numberOfIssuesIgnoredByBaseline(),
             ];
 
+            $arguments = [
+                ...$arguments,
+                ...$this->mergeDeprecationSummary($sum, $testResult),
+            ];
+
             /** @phpstan-ignore-next-line argument.type */
             $sum = new TestResult(...$arguments);
         }
 
         return $sum;
+    }
+
+    /**
+     * @return list<array<mixed>>
+     */
+    private function mergeDeprecationSummary(object $sum, object $testResult): array
+    {
+        $counts = [];
+
+        foreach ([
+            'self' => 'numberOfSelfDeprecations',
+            'direct' => 'numberOfDirectDeprecations',
+            'indirect' => 'numberOfIndirectDeprecations',
+            'unknown' => 'numberOfDeprecationsWithUnknownTrigger',
+        ] as $key => $method) {
+            if (! method_exists($sum, $method) || ! method_exists($testResult, $method)) {
+                return [];
+            }
+
+            $first = $sum->{$method}();
+            $second = $testResult->{$method}();
+
+            $counts[$key] = (is_int($first) ? $first : 0) + (is_int($second) ? $second : 0);
+        }
+
+        return [
+            $counts,
+            ...$this->mergeEventLists($sum, $testResult, ['retriedTests']),
+        ];
     }
 
     /**

--- a/tests/Drivers/ParatestTest.php
+++ b/tests/Drivers/ParatestTest.php
@@ -51,7 +51,11 @@ it('outputs json for deprecation tests', function (): void {
     $output = decodeOutput(runWith('paratest', 'DeprecationTest'));
 
     expect($output['result'])->toBe('passed')
-        ->and($output['tests'])->toBe(1);
+        ->and($output['tests'])->toBe(1)
+        ->and($output['deprecations'])->toBe(1)
+        ->and($output['deprecation_details'])->toHaveCount(1)
+        ->and($output['deprecation_details'][0]['file'])->toEndWith('DeprecationTest.php')
+        ->and($output['deprecation_details'][0]['message'])->toBe('This function is deprecated');
 });
 
 it('outputs json for warning tests', function (): void {
@@ -108,6 +112,35 @@ it('outputs json for multiple failures and errors', function (): void {
         ->and($output['errors'])->toBe(1)
         ->and($output['failures'])->toHaveCount(2)
         ->and($output['error_details'])->toHaveCount(1);
+});
+
+it('merges issues reported by multiple workers', function (): void {
+    $output = decodeOutput(runWith('paratest', 'Deprecation|Notice|Warning', extraArgs: ['--processes', '3']));
+
+    expect($output['result'])->toBe('passed')
+        ->and($output['tests'])->toBe(3)
+        ->and($output['passed'])->toBe(3)
+        ->and($output['deprecations'])->toBe(1)
+        ->and($output['warnings'])->toBe(1)
+        ->and($output['notices'])->toBe(1)
+        ->and($output['deprecation_details'][0]['file'])->toEndWith('DeprecationTest.php')
+        ->and($output['warning_details'][0]['file'])->toEndWith('WarningTest.php')
+        ->and($output['notice_details'][0]['file'])->toEndWith('NoticeTest.php');
+});
+
+it('merges test outcomes reported by multiple workers', function (): void {
+    $filter = 'RiskyTest|SkippedTest|IncompleteTest|FailingTest';
+
+    $output = decodeOutput(runWith('paratest', $filter, extraArgs: ['--processes', '4']));
+
+    expect($output['result'])->toBe('failed')
+        ->and($output['tests'])->toBe(5)
+        ->and($output['passed'])->toBe(3)
+        ->and($output['failed'])->toBe(1)
+        ->and($output['skipped'])->toBe(1)
+        ->and($output['incomplete'])->toBe(1)
+        ->and($output['risky'])->toBe(1)
+        ->and($output['failures'][0]['file'])->toEndWith('FailingTest.php');
 });
 
 it('outputs normal paratest output when no agent is detected', function (): void {


### PR DESCRIPTION
## Why

`php artisan test --parallel` fatals on PHPUnit 13.3.0 before printing any results:

```
Uncaught ArgumentCountError: Too few arguments to function
PHPUnit\TestRunner\TestResult\TestResult::__construct(), 31 passed in
src/Drivers/Paratest/WrapperRunner.php on line 158 and at least 32 expected
```

PHPUnit 13.3.0 added two constructor parameters to `TestRunner\TestResult\TestResult`:

- `array $numberOfDeprecationsByTrigger` (required, 32nd): from [#6827: Customize which deprecation trigger types fail the test run](https://github.com/sebastianbergmann/phpunit/pull/6827)
- `array $retriedTests = []` (optional, 33rd): from [#6742: Retry failing tests up to N times](https://github.com/sebastianbergmann/phpunit/pull/6742)

See the [13.3.0 changelog](https://github.com/sebastianbergmann/phpunit/blob/13.3.0/ChangeLog-13.3.md) and [`TestResult::__construct()`](https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/Runner/TestResult/TestResult.php#L234).

`mergeTestResults()` builds the argument list positionally and stopped at 31, so every parallel run dies at the result-merge step once the workers finish.

## What

Appends the two new arguments, guarded by `method_exists($sum, 'numberOfSelfDeprecations')`. The accessors do not exist before 13.3.0, so the merge stays correct on the older PHPUnit versions this package still supports (`>=12.5.23`, `>=13.1.7`). Same pattern as the existing `mergeEventLists()` guard.

`retriedTests` is optional and not needed to stop the fatal, but is merged so retry counts aren't dropped from the summary.

## Notes

Requires `brianium/paratest` >= 7.24.0 on PHPUnit 13.3, which resolves automatically. Paratest hit the parallel breakage first via the `Runner\ResultCache` >> `Runner\TestRunHistory` rename in the same release.